### PR TITLE
Bugfix - background / foreground layouting

### DIFF
--- a/Aiolos/Aiolos/Sources/PanelAnimator.swift
+++ b/Aiolos/Aiolos/Sources/PanelAnimator.swift
@@ -160,10 +160,12 @@ private extension PanelAnimator {
         // if we don't want to animate, perform changes directly by setting the completion state to 100 %
         if animated == false {
             animator.fractionComplete = 1.0
+            animator.stopAnimation(false)
+            animator.finishAnimation(at: .end)
+        } else {
+            animator.startAnimation()
+            self.animator = animator
         }
-
-        animator.startAnimation()
-        self.animator = animator
     }
 
     func addQueuedAnimations(to animator: UIViewPropertyAnimator) {


### PR DESCRIPTION
Finish animation immediately at fraction 1.0 if animated == false.
Otherwise (at least when app went from background to foreground) we have to stop active animations (also if the previous was `animated == false`).
With this method we assure also that completion blocks are called.