### PR TITLE
Allow the panel to be dragged to the opposite side of the screen

### DIFF
--- a/Aiolos/Aiolos.xcodeproj/project.pbxproj
+++ b/Aiolos/Aiolos.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		9B22527A1F150B14006DE55D /* Panel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2252791F150B14006DE55D /* Panel.swift */; };
 		9B22527E1F150F39006DE55D /* PanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B22527D1F150F39006DE55D /* PanelView.swift */; };
 		9B2252801F151046006DE55D /* PanelConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B22527F1F151046006DE55D /* PanelConfiguration.swift */; };
+		9B5B234A21FB481D00859947 /* UIView+RTL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B5B234921FB481D00859947 /* UIView+RTL.swift */; };
 		9BC45F8A1F320A860099EE5B /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9BC45F891F320A860099EE5B /* Launch Screen.storyboard */; };
 		9BC5F42F1F34757C001DDBEE /* ShadowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BC5F42E1F34757C001DDBEE /* ShadowView.swift */; };
 		9BC6A9411F3A03D100CE9499 /* PanelTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BC6A9401F3A03D100CE9499 /* PanelTransition.swift */; };
@@ -75,6 +76,7 @@
 		9B2252791F150B14006DE55D /* Panel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panel.swift; sourceTree = "<group>"; };
 		9B22527D1F150F39006DE55D /* PanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelView.swift; sourceTree = "<group>"; };
 		9B22527F1F151046006DE55D /* PanelConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelConfiguration.swift; sourceTree = "<group>"; };
+		9B5B234921FB481D00859947 /* UIView+RTL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+RTL.swift"; sourceTree = "<group>"; };
 		9BC45F891F320A860099EE5B /* Launch Screen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
 		9BC5F42E1F34757C001DDBEE /* ShadowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowView.swift; sourceTree = "<group>"; };
 		9BC6A9401F3A03D100CE9499 /* PanelTransition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelTransition.swift; sourceTree = "<group>"; };
@@ -164,6 +166,7 @@
 				9B22095F1F1E4CC700BD4E72 /* ResizeHandle.swift */,
 				9B037A8C1F3B618C00ACCC26 /* SeparatorView.swift */,
 				9BC5F42E1F34757C001DDBEE /* ShadowView.swift */,
+				9B5B234921FB481D00859947 /* UIView+RTL.swift */,
 				9B0A24721F34ACB500BCAA91 /* UIViewController+Panel.swift */,
 			);
 			path = Sources;
@@ -307,6 +310,7 @@
 				9BC6A9411F3A03D100CE9499 /* PanelTransition.swift in Sources */,
 				9B2209601F1E4CC700BD4E72 /* ResizeHandle.swift in Sources */,
 				9BC5F42F1F34757C001DDBEE /* ShadowView.swift in Sources */,
+				9B5B234A21FB481D00859947 /* UIView+RTL.swift in Sources */,
 				9BEB702F1F18F9C600EDB0C1 /* PanelGestures.swift in Sources */,
 				9B22527A1F150B14006DE55D /* Panel.swift in Sources */,
 			);

--- a/Aiolos/Aiolos/Sources/PanGestureRecognizer.swift
+++ b/Aiolos/Aiolos/Sources/PanGestureRecognizer.swift
@@ -71,7 +71,7 @@ public extension PanGestureRecognizer {
         if self.totalTranslation.hypotenuse() > Constants.minTranslation && self.didPan == false {
             self.didPan = true
 
-            // if we recognized a pan, make sure it can be considered a directional pan
+            // if we recognized a pan, make sure it can be considered a vertical pan
             guard self.totalTranslation.direction() == .vertical else {
                 self.state = .cancelled
                 return

--- a/Aiolos/Aiolos/Sources/PanGestureRecognizer.swift
+++ b/Aiolos/Aiolos/Sources/PanGestureRecognizer.swift
@@ -18,11 +18,6 @@ public final class PanGestureRecognizer: UIGestureRecognizer {
         case onFixedArea
         case onVerticallyScrollableArea(competingScrollView: UIScrollView)
     }
-    
-    enum Direction {
-        case horizontal
-        case vertical
-    }
 
     private lazy var panForVelocity: UIPanGestureRecognizer = self.makeVelocityPan()
     private var initialPoint: CGPoint?
@@ -33,7 +28,6 @@ public final class PanGestureRecognizer: UIGestureRecognizer {
 
     private(set) var didPan: Bool = false
     var startMode: StartMode = .onFixedArea
-    var panDirection: Direction = .vertical
 }
 
 // MARK: - UIGestureRecognizer+Subclass
@@ -78,7 +72,7 @@ public extension PanGestureRecognizer {
             self.didPan = true
 
             // if we recognized a pan, make sure it can be considered a directional pan
-            guard Direction(self.totalTranslation.direction()) == self.panDirection else {
+            guard self.totalTranslation.direction() == .vertical else {
                 self.state = .cancelled
                 return
             }
@@ -163,17 +157,6 @@ private extension PanGestureRecognizer {
         let endPointInView = window.convert(endPoint, to: view)
 
         return CGPoint(x: endPointInView.x - startPointInView.x, y: endPointInView.y - startPointInView.y)
-    }
-}
-
-private extension PanGestureRecognizer.Direction {
-    init(_ direction: CGPoint.Direction) {
-        switch direction {
-        case .horizontal:
-            self = .horizontal
-        case .vertical:
-            self = .vertical
-        }
     }
 }
 

--- a/Aiolos/Aiolos/Sources/PanGestureRecognizer.swift
+++ b/Aiolos/Aiolos/Sources/PanGestureRecognizer.swift
@@ -18,6 +18,11 @@ public final class PanGestureRecognizer: UIGestureRecognizer {
         case onFixedArea
         case onVerticallyScrollableArea(competingScrollView: UIScrollView)
     }
+    
+    enum Direction {
+        case horizontal
+        case vertical
+    }
 
     private lazy var panForVelocity: UIPanGestureRecognizer = self.makeVelocityPan()
     private var initialPoint: CGPoint?
@@ -28,6 +33,7 @@ public final class PanGestureRecognizer: UIGestureRecognizer {
 
     private(set) var didPan: Bool = false
     var startMode: StartMode = .onFixedArea
+    var panDirection: Direction = .vertical
 }
 
 // MARK: - UIGestureRecognizer+Subclass
@@ -71,8 +77,8 @@ public extension PanGestureRecognizer {
         if self.totalTranslation.hypotenuse() > Constants.minTranslation && self.didPan == false {
             self.didPan = true
 
-            // if we recognized a pan, make sure it can be considered a vertical pan
-            guard self.totalTranslation.direction() == .vertical else {
+            // if we recognized a pan, make sure it can be considered a directional pan
+            guard Direction(self.totalTranslation.direction()) == self.panDirection else {
                 self.state = .cancelled
                 return
             }
@@ -157,6 +163,17 @@ private extension PanGestureRecognizer {
         let endPointInView = window.convert(endPoint, to: view)
 
         return CGPoint(x: endPointInView.x - startPointInView.x, y: endPointInView.y - startPointInView.y)
+    }
+}
+
+private extension PanGestureRecognizer.Direction {
+    init(_ direction: CGPoint.Direction) {
+        switch direction {
+        case .horizontal:
+            self = .horizontal
+        case .vertical:
+            self = .vertical
+        }
     }
 }
 

--- a/Aiolos/Aiolos/Sources/Panel.swift
+++ b/Aiolos/Aiolos/Sources/Panel.swift
@@ -31,7 +31,6 @@ public final class Panel: UIViewController {
 
     @objc private(set) public lazy var panelView: PanelView = self.makePanelView()
     @objc public var isVisible: Bool { return self.parent != nil && self.animator.isTransitioningFromParent == false }
-    @objc public var isPanning: Bool { return self.gestures.isPanning }
     public weak var sizeDelegate: PanelSizeDelegate?
     public weak var animationDelegate: PanelAnimationDelegate?
     public weak var accessibilityDelegate: PanelAccessibilityDelegate? {

--- a/Aiolos/Aiolos/Sources/Panel.swift
+++ b/Aiolos/Aiolos/Sources/Panel.swift
@@ -34,7 +34,6 @@ public final class Panel: UIViewController {
     @objc public var isPanning: Bool { return self.gestures.isPanning }
     public weak var sizeDelegate: PanelSizeDelegate?
     public weak var animationDelegate: PanelAnimationDelegate?
-    public weak var positionDelegate: PanelPositionDelegate?
     public weak var accessibilityDelegate: PanelAccessibilityDelegate? {
         didSet {
             guard self.accessibilityDelegate !== oldValue else { return }

--- a/Aiolos/Aiolos/Sources/Panel.swift
+++ b/Aiolos/Aiolos/Sources/Panel.swift
@@ -34,6 +34,7 @@ public final class Panel: UIViewController {
     @objc public var isPanning: Bool { return self.gestures.isPanning }
     public weak var sizeDelegate: PanelSizeDelegate?
     public weak var animationDelegate: PanelAnimationDelegate?
+    public weak var positionDelegate: PanelPositionDelegate?
     public weak var accessibilityDelegate: PanelAccessibilityDelegate? {
         didSet {
             guard self.accessibilityDelegate !== oldValue else { return }

--- a/Aiolos/Aiolos/Sources/PanelAnimator.swift
+++ b/Aiolos/Aiolos/Sources/PanelAnimator.swift
@@ -82,7 +82,7 @@ final class PanelAnimator {
         }
     }
     
-    func notifyDelegateAboutMove(to frame: CGRect) -> Bool {
+    func askDelegateAboutMove(to frame: CGRect) -> Bool {
         guard let animationDelegate = self.panel.animationDelegate else { return false }
         guard self.panel.isVisible else { return false }
         

--- a/Aiolos/Aiolos/Sources/PanelAnimator.swift
+++ b/Aiolos/Aiolos/Sources/PanelAnimator.swift
@@ -82,6 +82,13 @@ final class PanelAnimator {
         }
     }
     
+    func askDelegateOfMove(to frame: CGRect) -> Bool {
+        guard let animationDelegate = self.panel.animationDelegate else { return false }
+        guard self.panel.isVisible else { return false }
+        
+        return animationDelegate.panel(self.panel, shouldMoveTo: frame)
+    }
+    
     func notifyDelegateOfWillMove(to frame: CGRect) {
         guard let animationDelegate = self.panel.animationDelegate else { return }
         guard self.panel.isVisible else { return }

--- a/Aiolos/Aiolos/Sources/PanelAnimator.swift
+++ b/Aiolos/Aiolos/Sources/PanelAnimator.swift
@@ -158,6 +158,24 @@ extension PanelAnimator {
         animator.startAnimation()
         self.animator = animator
     }
+
+    func transform(for direction: Panel.Direction, size: CGSize) -> CGAffineTransform {
+        guard let safeAreaInsets = self.panel.parent?.view.safeAreaInsets else { return .identity }
+        
+        let isRTL = self.panel.view.effectiveUserInterfaceLayoutDirection == .rightToLeft
+        let position = self.panel.configuration.position
+        let margins = self.panel.configuration.margins
+        
+        let animateToLeft = isRTL != (position == .leadingBottom)
+        
+        switch direction {
+        case .horizontal:
+            let translationX = animateToLeft ? -(size.width + margins.leading) : size.width + margins.trailing
+            return CGAffineTransform(translationX: translationX, y: 0.0)
+        case .vertical:
+            return CGAffineTransform(translationX: 0.0, y: size.height + margins.bottom + safeAreaInsets.bottom)
+        }
+    }
 }
 
 // MARK: - Private
@@ -241,23 +259,5 @@ private extension PanelAnimator {
 
         animator.startAnimation()
         self.animator = animator
-    }
-
-    func transform(for direction: Panel.Direction, size: CGSize) -> CGAffineTransform {
-        guard let safeAreaInsets = self.panel.parent?.view.safeAreaInsets else { return .identity }
-
-        let isRTL = self.panel.view.effectiveUserInterfaceLayoutDirection == .rightToLeft
-        let position = self.panel.configuration.position
-        let margins = self.panel.configuration.margins
-
-        let animateToLeft = isRTL != (position == .leadingBottom)
-
-        switch direction {
-        case .horizontal:
-            let translationX = animateToLeft ? -(size.width + margins.leading) : size.width + margins.trailing
-            return CGAffineTransform(translationX: translationX, y: 0.0)
-        case .vertical:
-            return CGAffineTransform(translationX: 0.0, y: size.height + margins.bottom + safeAreaInsets.bottom)
-        }
     }
 }

--- a/Aiolos/Aiolos/Sources/PanelAnimator.swift
+++ b/Aiolos/Aiolos/Sources/PanelAnimator.swift
@@ -83,17 +83,18 @@ final class PanelAnimator {
     }
     
     func notifyDelegateOfMove(to frame: CGRect) {
-        guard let positionDelegate = self.panel.positionDelegate else { return }
+        guard let animationDelegate = self.panel.animationDelegate else { return }
         guard self.panel.isVisible else { return }
     
-        positionDelegate.panel(self.panel, willMoveTo: frame)
+        animationDelegate.panel(self.panel, willMoveTo: frame)
     }
     
     func notifyDelegateOfMove(from oldPosition: Panel.Configuration.Position, to newPosition: Panel.Configuration.Position) {
-        guard let positionDelegate = self.panel.positionDelegate else { return }
+        guard let animationDelegate = self.panel.animationDelegate else { return }
         guard self.panel.isVisible else { return }
         
-        positionDelegate.panel(self.panel, willMoveFrom: oldPosition, to: newPosition)
+        let transitionCoordinator = PanelTransitionCoordinator(animator: self)
+        animationDelegate.panel(self.panel, willMoveFrom: oldPosition, to: newPosition, with: transitionCoordinator)
     }
 }
 

--- a/Aiolos/Aiolos/Sources/PanelAnimator.swift
+++ b/Aiolos/Aiolos/Sources/PanelAnimator.swift
@@ -100,7 +100,7 @@ final class PanelAnimator {
         guard let animationDelegate = self.panel.animationDelegate else { return }
         guard self.panel.isVisible else { return }
         
-        let transitionContext = PanelTransitionCoordinator.HorizontalTransitionContext.init(panel: self.panel, pan: pan, originalFrame: origin)
+        let transitionContext = PanelTransitionCoordinator.HorizontalTransitionContext(panel: self.panel, pan: pan, originalFrame: origin)
         let transitionCoordinator = PanelTransitionCoordinator(animator: self, context: transitionContext)
         animationDelegate.panel(self.panel, didMoveFrom: origin, to: destination, with: transitionCoordinator)
     }

--- a/Aiolos/Aiolos/Sources/PanelAnimator.swift
+++ b/Aiolos/Aiolos/Sources/PanelAnimator.swift
@@ -89,12 +89,12 @@ final class PanelAnimator {
         return animationDelegate.panel(self.panel, shouldMoveTo: frame)
     }
     
-    func notifyDelegateOfMove(from origin: CGRect, to destination: CGRect, context: PanelTransitionCoordinator.HorizontalTransitionContext) {
+    func notifyDelegateOfMove(from oldFrame: CGRect, to newFrame: CGRect, context: PanelTransitionCoordinator.HorizontalTransitionContext) {
         guard let animationDelegate = self.panel.animationDelegate else { return }
         guard self.panel.isVisible else { return }
         
         let transitionCoordinator = PanelTransitionCoordinator(animator: self, direction: .horizontal(context: context))
-        animationDelegate.panel(self.panel, didMoveFrom: origin, to: destination, with: transitionCoordinator)
+        animationDelegate.panel(self.panel, didMoveFrom: oldFrame, to: newFrame, with: transitionCoordinator)
     }
 }
 

--- a/Aiolos/Aiolos/Sources/PanelAnimator.swift
+++ b/Aiolos/Aiolos/Sources/PanelAnimator.swift
@@ -89,12 +89,12 @@ final class PanelAnimator {
         return animationDelegate.panel(self.panel, shouldMoveTo: frame)
     }
     
-    func notifyDelegateOfMove(from oldFrame: CGRect, to newFrame: CGRect, context: PanelTransitionCoordinator.HorizontalTransitionContext) {
-        guard let animationDelegate = self.panel.animationDelegate else { return }
-        guard self.panel.isVisible else { return }
+    func askDelegateOfMove(from oldFrame: CGRect, to newFrame: CGRect, context: PanelTransitionCoordinator.HorizontalTransitionContext) -> PanelTransitionCoordinator.Instruction {
+        guard let animationDelegate = self.panel.animationDelegate else { return .none }
+        guard self.panel.isVisible else { return .none }
         
         let transitionCoordinator = PanelTransitionCoordinator(animator: self, direction: .horizontal(context: context))
-        animationDelegate.panel(self.panel, didMoveFrom: oldFrame, to: newFrame, with: transitionCoordinator)
+        return animationDelegate.panel(self.panel, didMoveFrom: oldFrame, to: newFrame, with: transitionCoordinator)
     }
 }
 

--- a/Aiolos/Aiolos/Sources/PanelAnimator.swift
+++ b/Aiolos/Aiolos/Sources/PanelAnimator.swift
@@ -89,12 +89,11 @@ final class PanelAnimator {
         return animationDelegate.panel(self.panel, shouldMoveTo: frame)
     }
     
-    func notifyDelegateOfDidMove(from origin: CGRect, to destination: CGRect, pan: PanGestureRecognizer) {
+    func notifyDelegateOfDidMove(from origin: CGRect, to destination: CGRect, context: PanelTransitionCoordinator.HorizontalTransitionContext) {
         guard let animationDelegate = self.panel.animationDelegate else { return }
         guard self.panel.isVisible else { return }
         
-        let transitionContext = PanelTransitionCoordinator.HorizontalTransitionContext(panel: self.panel, pan: pan, originalFrame: origin)
-        let transitionCoordinator = PanelTransitionCoordinator(animator: self, direction: .horizontal(context: transitionContext))
+        let transitionCoordinator = PanelTransitionCoordinator(animator: self, direction: .horizontal(context: context))
         animationDelegate.panel(self.panel, didMoveFrom: origin, to: destination, with: transitionCoordinator)
     }
 }

--- a/Aiolos/Aiolos/Sources/PanelAnimator.swift
+++ b/Aiolos/Aiolos/Sources/PanelAnimator.swift
@@ -89,7 +89,7 @@ final class PanelAnimator {
         return animationDelegate.panel(self.panel, shouldMoveTo: frame)
     }
     
-    func askDelegateOfMove(from oldFrame: CGRect, to newFrame: CGRect, context: PanelTransitionCoordinator.HorizontalTransitionContext) -> PanelTransitionCoordinator.Instruction {
+    func notifyDelegateOfMove(from oldFrame: CGRect, to newFrame: CGRect, context: PanelTransitionCoordinator.HorizontalTransitionContext) -> PanelTransitionCoordinator.Instruction {
         guard let animationDelegate = self.panel.animationDelegate else { return .none }
         guard self.panel.isVisible else { return .none }
         
@@ -161,12 +161,10 @@ extension PanelAnimator {
 
     func transform(for direction: Panel.Direction, size: CGSize) -> CGAffineTransform {
         guard let safeAreaInsets = self.panel.parent?.view.safeAreaInsets else { return .identity }
-        
-        let isRTL = self.panel.view.effectiveUserInterfaceLayoutDirection == .rightToLeft
+
         let position = self.panel.configuration.position
         let margins = self.panel.configuration.margins
-        
-        let animateToLeft = isRTL != (position == .leadingBottom)
+        let animateToLeft = self.panel.view.isRTL != (position == .leadingBottom)
         
         switch direction {
         case .horizontal:

--- a/Aiolos/Aiolos/Sources/PanelAnimator.swift
+++ b/Aiolos/Aiolos/Sources/PanelAnimator.swift
@@ -81,6 +81,20 @@ final class PanelAnimator {
             contentViewController.panel(self.panel, willTransitionFrom: oldMode, to: newMode, with: transitionCoordinator)
         }
     }
+    
+    func notifyDelegateOfMove(to frame: CGRect) {
+        guard let positionDelegate = self.panel.positionDelegate else { return }
+        guard self.panel.isVisible else { return }
+    
+        positionDelegate.panel(self.panel, willMoveTo: frame)
+    }
+    
+    func notifyDelegateOfMove(from oldPosition: Panel.Configuration.Position, to newPosition: Panel.Configuration.Position) {
+        guard let positionDelegate = self.panel.positionDelegate else { return }
+        guard self.panel.isVisible else { return }
+        
+        positionDelegate.panel(self.panel, willMoveFrom: oldPosition, to: newPosition)
+    }
 }
 
 // MARK: - Transitions

--- a/Aiolos/Aiolos/Sources/PanelAnimator.swift
+++ b/Aiolos/Aiolos/Sources/PanelAnimator.swift
@@ -82,14 +82,14 @@ final class PanelAnimator {
         }
     }
     
-    func askDelegateOfMove(to frame: CGRect) -> Bool {
+    func notifyDelegateAboutMove(to frame: CGRect) -> Bool {
         guard let animationDelegate = self.panel.animationDelegate else { return false }
         guard self.panel.isVisible else { return false }
         
         return animationDelegate.panel(self.panel, shouldMoveTo: frame)
     }
     
-    func notifyDelegateOfDidMove(from origin: CGRect, to destination: CGRect, context: PanelTransitionCoordinator.HorizontalTransitionContext) {
+    func notifyDelegateOfMove(from origin: CGRect, to destination: CGRect, context: PanelTransitionCoordinator.HorizontalTransitionContext) {
         guard let animationDelegate = self.panel.animationDelegate else { return }
         guard self.panel.isVisible else { return }
         

--- a/Aiolos/Aiolos/Sources/PanelAnimator.swift
+++ b/Aiolos/Aiolos/Sources/PanelAnimator.swift
@@ -97,14 +97,6 @@ final class PanelAnimator {
         let transitionCoordinator = PanelTransitionCoordinator(animator: self, context: transitionContext)
         animationDelegate.panel(self.panel, didMoveFrom: origin, to: destination, with: transitionCoordinator)
     }
-    
-    func notifyDelegateOfWillMove(from oldPosition: Panel.Configuration.Position, to newPosition: Panel.Configuration.Position) {
-        guard let animationDelegate = self.panel.animationDelegate else { return }
-        guard self.panel.isVisible else { return }
-        
-        let transitionCoordinator = PanelTransitionCoordinator(animator: self)
-        animationDelegate.panel(self.panel, willMoveFrom: oldPosition, to: newPosition, with: transitionCoordinator)
-    }
 }
 
 // MARK: - Transitions

--- a/Aiolos/Aiolos/Sources/PanelAnimator.swift
+++ b/Aiolos/Aiolos/Sources/PanelAnimator.swift
@@ -82,14 +82,23 @@ final class PanelAnimator {
         }
     }
     
-    func notifyDelegateOfMove(to frame: CGRect) {
+    func notifyDelegateOfWillMove(to frame: CGRect) {
         guard let animationDelegate = self.panel.animationDelegate else { return }
         guard self.panel.isVisible else { return }
     
         animationDelegate.panel(self.panel, willMoveTo: frame)
     }
     
-    func notifyDelegateOfMove(from oldPosition: Panel.Configuration.Position, to newPosition: Panel.Configuration.Position) {
+    func notifyDelegateOfDidMove(from origin: CGRect, to destination: CGRect, pan: PanGestureRecognizer) {
+        guard let animationDelegate = self.panel.animationDelegate else { return }
+        guard self.panel.isVisible else { return }
+        
+        let transitionContext = PanelTransitionCoordinator.HorizontalTransitionContext.init(panel: self.panel, pan: pan, originalFrame: origin)
+        let transitionCoordinator = PanelTransitionCoordinator(animator: self, context: transitionContext)
+        animationDelegate.panel(self.panel, didMoveFrom: origin, to: destination, with: transitionCoordinator)
+    }
+    
+    func notifyDelegateOfWillMove(from oldPosition: Panel.Configuration.Position, to newPosition: Panel.Configuration.Position) {
         guard let animationDelegate = self.panel.animationDelegate else { return }
         guard self.panel.isVisible else { return }
         

--- a/Aiolos/Aiolos/Sources/PanelAnimator.swift
+++ b/Aiolos/Aiolos/Sources/PanelAnimator.swift
@@ -75,7 +75,7 @@ final class PanelAnimator {
         guard let animationDelegate = self.panel.animationDelegate else { return }
         guard self.panel.isVisible else { return }
 
-        let transitionCoordinator = PanelTransitionCoordinator(animator: self)
+        let transitionCoordinator = PanelTransitionCoordinator(animator: self, direction: .vertical)
         animationDelegate.panel(self.panel, willTransitionFrom: oldMode, to: newMode, with: transitionCoordinator)
         if let contentViewController = self.panel.contentViewController as? PanelAnimationDelegate {
             contentViewController.panel(self.panel, willTransitionFrom: oldMode, to: newMode, with: transitionCoordinator)
@@ -94,7 +94,7 @@ final class PanelAnimator {
         guard self.panel.isVisible else { return }
         
         let transitionContext = PanelTransitionCoordinator.HorizontalTransitionContext(panel: self.panel, pan: pan, originalFrame: origin)
-        let transitionCoordinator = PanelTransitionCoordinator(animator: self, context: transitionContext)
+        let transitionCoordinator = PanelTransitionCoordinator(animator: self, direction: .horizontal(context: transitionContext))
         animationDelegate.panel(self.panel, didMoveFrom: origin, to: destination, with: transitionCoordinator)
     }
 }

--- a/Aiolos/Aiolos/Sources/PanelAnimator.swift
+++ b/Aiolos/Aiolos/Sources/PanelAnimator.swift
@@ -89,13 +89,6 @@ final class PanelAnimator {
         return animationDelegate.panel(self.panel, shouldMoveTo: frame)
     }
     
-    func notifyDelegateOfWillMove(to frame: CGRect) {
-        guard let animationDelegate = self.panel.animationDelegate else { return }
-        guard self.panel.isVisible else { return }
-    
-        animationDelegate.panel(self.panel, willMoveTo: frame)
-    }
-    
     func notifyDelegateOfDidMove(from origin: CGRect, to destination: CGRect, pan: PanGestureRecognizer) {
         guard let animationDelegate = self.panel.animationDelegate else { return }
         guard self.panel.isVisible else { return }

--- a/Aiolos/Aiolos/Sources/PanelConfiguration.swift
+++ b/Aiolos/Aiolos/Sources/PanelConfiguration.swift
@@ -146,7 +146,6 @@ extension Panel.Configuration.PositionLogic {
 
     func applyingInsets(of view: UIView, to insets: NSDirectionalEdgeInsets, edge: Panel.Configuration.Edge) -> NSDirectionalEdgeInsets {
         var insets = insets
-        let isRTL = view.effectiveUserInterfaceLayoutDirection == .rightToLeft
 
         switch (self, edge) {
         case (.ignoreSafeArea, _):
@@ -155,11 +154,11 @@ extension Panel.Configuration.PositionLogic {
         case (.respectSafeArea, .top):
             insets.top = view.safeAreaInsets.top
         case (.respectSafeArea, .leading):
-            insets.leading = isRTL ? view.safeAreaInsets.right : view.safeAreaInsets.left
+            insets.leading = view.isRTL ? view.safeAreaInsets.right : view.safeAreaInsets.left
         case (.respectSafeArea, .bottom):
             insets.bottom = view.safeAreaInsets.bottom
         case (.respectSafeArea, .trailing):
-            insets.trailing = isRTL ? view.safeAreaInsets.left : view.safeAreaInsets.right
+            insets.trailing = view.isRTL ? view.safeAreaInsets.left : view.safeAreaInsets.right
         }
 
         return insets

--- a/Aiolos/Aiolos/Sources/PanelConfiguration.swift
+++ b/Aiolos/Aiolos/Sources/PanelConfiguration.swift
@@ -52,6 +52,12 @@ public extension Panel {
             case excludingContent
             case includingContent
         }
+        
+        // TODO: Review the naming and cases
+        public enum GesturePositioningMode: Int {
+            case disabled
+            case enabled
+        }
 
         public struct Appearance {
             public var visualEffect: UIVisualEffect?
@@ -73,6 +79,7 @@ public extension Panel {
         public var supportedModes: Set<Mode>
         public var gestureResizingMode: GestureResizingMode
         public var appearance: Appearance
+        public var gesturePositioningMode: GesturePositioningMode
     }
 }
 
@@ -96,7 +103,8 @@ public extension Panel.Configuration {
                                    mode: .compact,
                                    supportedModes: [.compact, .expanded, .fullHeight],
                                    gestureResizingMode: .includingContent,
-                                   appearance: appearance)
+                                   appearance: appearance,
+                                   gesturePositioningMode: .enabled)
     }
 }
 

--- a/Aiolos/Aiolos/Sources/PanelConfiguration.swift
+++ b/Aiolos/Aiolos/Sources/PanelConfiguration.swift
@@ -74,7 +74,7 @@ public extension Panel {
         public var supportedModes: Set<Mode>
         public var gestureResizingMode: GestureResizingMode
         public var appearance: Appearance
-        public var horizontalPositioningEnabled: Bool
+        public var horizontalPositioningEnabled: Bool { return self.supportedPositions.count > 1 }
     }
 }
 
@@ -94,13 +94,12 @@ public extension Panel.Configuration {
 
         return Panel.Configuration(position: .bottom,
                                    positionLogic: PositionLogic.respectAllSafeAreas,
-                                   supportedPositions: [.bottom, .leadingBottom, .trailingBottom],
+                                   supportedPositions: [.bottom],
                                    margins: NSDirectionalEdgeInsets(top: 10.0, leading: 10.0, bottom: 0.0, trailing: 10.0),
                                    mode: .compact,
                                    supportedModes: [.compact, .expanded, .fullHeight],
                                    gestureResizingMode: .includingContent,
-                                   appearance: appearance,
-                                   horizontalPositioningEnabled: true)
+                                   appearance: appearance)
     }
 }
 
@@ -130,27 +129,11 @@ extension Panel.Configuration {
                 }
             }
         }
-        
-        if validated.supportedPositions.isEmpty {
-            // can't have an empty `supportedPositions` array
-            validated.supportedPositions.insert(validated.position)
-        } else {
-            // position must be included in `supportedPositions`
-            if validated.supportedPositions.contains(validated.position) == false {
-                let fallbackPositions: [Position: Position] = [
-                    .leadingBottom: .bottom,
-                    .trailingBottom: .bottom,
-                    .bottom: .leadingBottom,
-                ]
-                
-                if let fallbackPosition = fallbackPositions[validated.position], validated.supportedPositions.contains(fallbackPosition) {
-                    validated.position = fallbackPosition
-                } else {
-                    validated.position = validated.supportedPositions.first!
-                }
-            }
-        }
 
+        // position must be included in `supportedPositions`
+        validated.supportedPositions.insert(validated.position)
+
+        // positionLogic must be defined for every edge
         for edge in [Edge.top, .leading, .bottom, .trailing] where validated.positionLogic[edge] == nil {
             validated.positionLogic[edge] = .respectSafeArea
         }

--- a/Aiolos/Aiolos/Sources/PanelConfiguration.swift
+++ b/Aiolos/Aiolos/Sources/PanelConfiguration.swift
@@ -74,6 +74,7 @@ public extension Panel {
 
         public var position: Position
         public var positionLogic: [Edge: PositionLogic]
+        public var supportedPositions: Set<Position>
         public var margins: NSDirectionalEdgeInsets
         public var mode: Mode
         public var supportedModes: Set<Mode>
@@ -99,6 +100,7 @@ public extension Panel.Configuration {
 
         return Panel.Configuration(position: .bottom,
                                    positionLogic: PositionLogic.respectAllSafeAreas,
+                                   supportedPositions: [.bottom, .leadingBottom, .trailingBottom],
                                    margins: NSDirectionalEdgeInsets(top: 10.0, leading: 10.0, bottom: 0.0, trailing: 10.0),
                                    mode: .compact,
                                    supportedModes: [.compact, .expanded, .fullHeight],
@@ -131,6 +133,26 @@ extension Panel.Configuration {
                     validated.mode = fallbackMode
                 } else {
                     validated.mode = validated.supportedModes.first!
+                }
+            }
+        }
+        
+        if validated.supportedPositions.isEmpty {
+            // can't have an empty `supportedPositions` array
+            validated.supportedPositions.insert(validated.position)
+        } else {
+            // position must be included in `supportedPositions`
+            if validated.supportedPositions.contains(validated.position) == false {
+                let fallbackPositions: [Position: Position] = [
+                    .leadingBottom: .bottom,
+                    .trailingBottom: .bottom,
+                    .bottom: .leadingBottom,
+                ]
+                
+                if let fallbackPosition = fallbackPositions[validated.position], validated.supportedPositions.contains(fallbackPosition) {
+                    validated.position = fallbackPosition
+                } else {
+                    validated.position = validated.supportedPositions.first!
                 }
             }
         }

--- a/Aiolos/Aiolos/Sources/PanelConfiguration.swift
+++ b/Aiolos/Aiolos/Sources/PanelConfiguration.swift
@@ -52,12 +52,6 @@ public extension Panel {
             case excludingContent
             case includingContent
         }
-        
-        // TODO: Review the naming and cases
-        public enum GesturePositioningMode: Int {
-            case disabled
-            case enabled
-        }
 
         public struct Appearance {
             public var visualEffect: UIVisualEffect?
@@ -80,7 +74,7 @@ public extension Panel {
         public var supportedModes: Set<Mode>
         public var gestureResizingMode: GestureResizingMode
         public var appearance: Appearance
-        public var gesturePositioningMode: GesturePositioningMode
+        public var horizontalPositioningEnabled: Bool
     }
 }
 
@@ -106,7 +100,7 @@ public extension Panel.Configuration {
                                    supportedModes: [.compact, .expanded, .fullHeight],
                                    gestureResizingMode: .includingContent,
                                    appearance: appearance,
-                                   gesturePositioningMode: .enabled)
+                                   horizontalPositioningEnabled: true)
     }
 }
 

--- a/Aiolos/Aiolos/Sources/PanelConstraints.swift
+++ b/Aiolos/Aiolos/Sources/PanelConstraints.swift
@@ -90,16 +90,26 @@ final class PanelConstraints {
 
 internal extension PanelConstraints {
 
-    var maxHeight: CGFloat {
-        guard let parentView = self.panel.parent?.view else { return 0.0 }
-
+    var safeArea: CGRect {
+        guard let parentView = self.panel.parent?.view else { return .zero }
+        
         var insets: NSDirectionalEdgeInsets = .zero
         for (edge, positionLogic) in self.panel.configuration.positionLogic {
             insets = positionLogic.applyingInsets(of: parentView, to: insets, edge: edge)
         }
+        
+        return parentView.bounds.inset(by: UIEdgeInsets(directionalEdgeInsets: insets, isRTL: parentView.effectiveUserInterfaceLayoutDirection == .rightToLeft))
+    }
 
-        let safeArea = parentView.bounds.inset(by: UIEdgeInsets(directionalEdgeInsets: insets, isRTL: parentView.effectiveUserInterfaceLayoutDirection == .rightToLeft))
-        return self.panel.view.frame.maxY - safeArea.minY
+    var effectiveBounds: CGRect {
+        guard let parentView = self.panel.parent?.view else { return .zero }
+        
+        let insets = self.panel.configuration.margins
+        return self.safeArea.inset(by: UIEdgeInsets(directionalEdgeInsets: insets, isRTL: parentView.effectiveUserInterfaceLayoutDirection == .rightToLeft))
+    }
+
+    var maxHeight: CGFloat {
+        return self.panel.view.frame.maxY - self.safeArea.minY
     }
 
     func updateForPanStart(with currentSize: CGSize) {

--- a/Aiolos/Aiolos/Sources/PanelConstraints.swift
+++ b/Aiolos/Aiolos/Sources/PanelConstraints.swift
@@ -13,7 +13,7 @@ import Foundation
 final class PanelConstraints {
 
     private unowned let panel: Panel
-    private var isPanning: Bool = false
+    private var isResizing: Bool = false
     private lazy var keyboardLayoutGuide: KeyboardLayoutGuide = self.makeKeyboardLayoutGuide()
     private var topConstraint: NSLayoutConstraint?
     private var topConstraintMargin: CGFloat = 0.0
@@ -30,7 +30,7 @@ final class PanelConstraints {
     // MARK: - PanelConstraints
 
     func updateSizeConstraints(for size: CGSize) {
-        guard self.isPanning == false else { return }
+        guard self.isResizing == false else { return }
         guard let widthConstraint = self.widthConstraint, let heightConstraint = self.heightConstraint else {
             self.activateSizeConstraints(for: size)
             return
@@ -43,7 +43,7 @@ final class PanelConstraints {
     }
 
     func updatePositionConstraints(for position: Panel.Configuration.Position, margins: NSDirectionalEdgeInsets) {
-        guard self.isPanning == false else { return }
+        guard self.isResizing == false else { return }
         guard let view = self.panel.view else { return }
         guard let parentView = self.panel.parent?.view else { return }
 
@@ -111,28 +111,28 @@ internal extension PanelConstraints {
     }
 
     func updateForPan(with yOffset: CGFloat) {
-        self.isPanning = true
+        self.isResizing = true
         self.heightConstraint?.constant -= yOffset
     }
 
     func updateForPanEnd() {
         self.setTopConstraintIsRelaxed(false)
-        self.isPanning = false
+        self.isResizing = false
     }
 
     func prepareForPanEndAnimation() {
-        self.isPanning = true
+        self.isResizing = true
     }
 
     func updateForPanEndAnimation(to height: CGFloat) {
         self.heightConstraint?.constant = height
         self.panel.parent?.view.layoutIfNeeded()
-        self.isPanning = false
+        self.isResizing = false
     }
 
     func updateForPanCancelled(with targetSize: CGSize) {
         self.setTopConstraintIsRelaxed(false)
-        self.isPanning = false
+        self.isResizing = false
         self.updateSizeConstraints(for: targetSize)
     }
 }

--- a/Aiolos/Aiolos/Sources/PanelConstraints.swift
+++ b/Aiolos/Aiolos/Sources/PanelConstraints.swift
@@ -98,14 +98,14 @@ internal extension PanelConstraints {
             insets = positionLogic.applyingInsets(of: parentView, to: insets, edge: edge)
         }
         
-        return parentView.bounds.inset(by: UIEdgeInsets(directionalEdgeInsets: insets, isRTL: parentView.effectiveUserInterfaceLayoutDirection == .rightToLeft))
+        return parentView.bounds.inset(by: UIEdgeInsets(directionalEdgeInsets: insets, isRTL: parentView.isRTL))
     }
 
     var effectiveBounds: CGRect {
         guard let parentView = self.panel.parent?.view else { return .zero }
         
         let insets = self.panel.configuration.margins
-        return self.safeArea.inset(by: UIEdgeInsets(directionalEdgeInsets: insets, isRTL: parentView.effectiveUserInterfaceLayoutDirection == .rightToLeft))
+        return self.safeArea.inset(by: UIEdgeInsets(directionalEdgeInsets: insets, isRTL: parentView.isRTL))
     }
 
     var maxHeight: CGFloat {

--- a/Aiolos/Aiolos/Sources/PanelDelegate.swift
+++ b/Aiolos/Aiolos/Sources/PanelDelegate.swift
@@ -29,7 +29,7 @@ public protocol PanelAnimationDelegate: AnyObject {
     func panel(_ panel: Panel, shouldMoveTo frame: CGRect) -> Bool
     
     /// Tells the delegate that the `panel` did move to a specific frame
-    func panel(_ panel: Panel, didMoveFrom origin: CGRect, to destination: CGRect, with coordinator: PanelTransitionCoordinator)
+    func panel(_ panel: Panel, didMoveFrom oldFrame: CGRect, to newFrame: CGRect, with coordinator: PanelTransitionCoordinator)
 }
 
 public protocol PanelAccessibilityDelegate: AnyObject {

--- a/Aiolos/Aiolos/Sources/PanelDelegate.swift
+++ b/Aiolos/Aiolos/Sources/PanelDelegate.swift
@@ -26,6 +26,14 @@ public protocol PanelAnimationDelegate: AnyObject {
     func panel(_ panel: Panel, willTransitionFrom oldMode: Panel.Configuration.Mode?, to newMode: Panel.Configuration.Mode, with coordinator: PanelTransitionCoordinator)
 }
 
+// TODO: PanelPositionDelegate
+
+public protocol PanelPositionDelegate: AnyObject {
+    
+    /// Tells the delegate that the `panel` is moving to a specific position
+    func panel(_ panel: Panel, willMoveTo position: Panel.Configuration.Position)
+}
+
 public protocol PanelAccessibilityDelegate: AnyObject {
 
     /// Asks the delegate for the accessibility label of the resize handle

--- a/Aiolos/Aiolos/Sources/PanelDelegate.swift
+++ b/Aiolos/Aiolos/Sources/PanelDelegate.swift
@@ -17,11 +17,6 @@ public protocol PanelSizeDelegate: AnyObject {
     func panel(_ panel: Panel, sizeForMode mode: Panel.Configuration.Mode) -> CGSize
 }
 
-public protocol PanelPositionDelegate: AnyObject {
-    
-    // TODO: Let the delegate to decide what to do when panel is dragged to a certain offset (either swift side or hide)
-}
-
 public protocol PanelAnimationDelegate: AnyObject {
 
     /// Tells the delegate that the `panel` is transitioning to a specific size

--- a/Aiolos/Aiolos/Sources/PanelDelegate.swift
+++ b/Aiolos/Aiolos/Sources/PanelDelegate.swift
@@ -17,6 +17,11 @@ public protocol PanelSizeDelegate: AnyObject {
     func panel(_ panel: Panel, sizeForMode mode: Panel.Configuration.Mode) -> CGSize
 }
 
+public protocol PanelPositionDelegate: AnyObject {
+    
+    // TODO: Let the delegate to decide what to do when panel is dragged to a certain offset (either swift side or hide)
+}
+
 public protocol PanelAnimationDelegate: AnyObject {
 
     /// Tells the delegate that the `panel` is transitioning to a specific size
@@ -24,19 +29,12 @@ public protocol PanelAnimationDelegate: AnyObject {
 
     /// Tells the delegate that the `panel` is transitioning to a specific mode
     func panel(_ panel: Panel, willTransitionFrom oldMode: Panel.Configuration.Mode?, to newMode: Panel.Configuration.Mode, with coordinator: PanelTransitionCoordinator)
-}
-
-public protocol PanelPositionDelegate: AnyObject {
-
-    // TODO: Let the delegate to decide what to do when panel is dragged to a certain offset (either swift side or hide)
-    
-    // TODO: Provide `PanelTransitionCoordinator` as a param in `panel(:willMoveFrom:to)` method?
     
     /// Tells the delegate that the `panel` is moving to a specific frame
     func panel(_ panel: Panel, willMoveTo frame: CGRect)
     
     /// Tells the delegate that the `panel` is moving to a specific position
-    func panel(_ panel: Panel, willMoveFrom oldPosition: Panel.Configuration.Position, to newPosition: Panel.Configuration.Position)
+    func panel(_ panel: Panel, willMoveFrom oldPosition: Panel.Configuration.Position, to newPosition: Panel.Configuration.Position, with coordinator: PanelTransitionCoordinator)
 }
 
 public protocol PanelAccessibilityDelegate: AnyObject {

--- a/Aiolos/Aiolos/Sources/PanelDelegate.swift
+++ b/Aiolos/Aiolos/Sources/PanelDelegate.swift
@@ -25,6 +25,9 @@ public protocol PanelAnimationDelegate: AnyObject {
     /// Tells the delegate that the `panel` is transitioning to a specific mode
     func panel(_ panel: Panel, willTransitionFrom oldMode: Panel.Configuration.Mode?, to newMode: Panel.Configuration.Mode, with coordinator: PanelTransitionCoordinator)
     
+    /// Asks the delegate if the `panel` can move to a specific frame
+    func panel(_ panel: Panel, shouldMoveTo frame: CGRect) -> Bool
+    
     /// Tells the delegate that the `panel` is moving to a specific frame
     func panel(_ panel: Panel, willMoveTo frame: CGRect)
     

--- a/Aiolos/Aiolos/Sources/PanelDelegate.swift
+++ b/Aiolos/Aiolos/Sources/PanelDelegate.swift
@@ -30,9 +30,6 @@ public protocol PanelAnimationDelegate: AnyObject {
     
     /// Tells the delegate that the `panel` did move to a specific frame
     func panel(_ panel: Panel, didMoveFrom origin: CGRect, to destination: CGRect, with coordinator: PanelTransitionCoordinator)
-    
-    /// Tells the delegate that the `panel` is moving to a specific position
-    func panel(_ panel: Panel, willMoveFrom oldPosition: Panel.Configuration.Position, to newPosition: Panel.Configuration.Position, with coordinator: PanelTransitionCoordinator)
 }
 
 public protocol PanelAccessibilityDelegate: AnyObject {

--- a/Aiolos/Aiolos/Sources/PanelDelegate.swift
+++ b/Aiolos/Aiolos/Sources/PanelDelegate.swift
@@ -29,7 +29,7 @@ public protocol PanelAnimationDelegate: AnyObject {
     func panel(_ panel: Panel, shouldMoveTo frame: CGRect) -> Bool
     
     /// Tells the delegate that the `panel` did move to a specific frame
-    func panel(_ panel: Panel, didMoveFrom oldFrame: CGRect, to newFrame: CGRect, with coordinator: PanelTransitionCoordinator)
+    func panel(_ panel: Panel, didMoveFrom oldFrame: CGRect, to newFrame: CGRect, with coordinator: PanelTransitionCoordinator) -> PanelTransitionCoordinator.Instruction
 }
 
 public protocol PanelAccessibilityDelegate: AnyObject {

--- a/Aiolos/Aiolos/Sources/PanelDelegate.swift
+++ b/Aiolos/Aiolos/Sources/PanelDelegate.swift
@@ -28,9 +28,6 @@ public protocol PanelAnimationDelegate: AnyObject {
     /// Asks the delegate if the `panel` can move to a specific frame
     func panel(_ panel: Panel, shouldMoveTo frame: CGRect) -> Bool
     
-    /// Tells the delegate that the `panel` is moving to a specific frame
-    func panel(_ panel: Panel, willMoveTo frame: CGRect)
-    
     /// Tells the delegate that the `panel` did move to a specific frame
     func panel(_ panel: Panel, didMoveFrom origin: CGRect, to destination: CGRect, with coordinator: PanelTransitionCoordinator)
 }

--- a/Aiolos/Aiolos/Sources/PanelDelegate.swift
+++ b/Aiolos/Aiolos/Sources/PanelDelegate.swift
@@ -26,12 +26,15 @@ public protocol PanelAnimationDelegate: AnyObject {
     func panel(_ panel: Panel, willTransitionFrom oldMode: Panel.Configuration.Mode?, to newMode: Panel.Configuration.Mode, with coordinator: PanelTransitionCoordinator)
 }
 
-// TODO: PanelPositionDelegate
-
 public protocol PanelPositionDelegate: AnyObject {
+
+    // TODO: Let the delegate to decide what to do when panel is dragged to a certain offset (either swift side or hide)
+    
+    /// Tells the delegate that the `panel` is moving to a specific frame
+    func panel(_ panel: Panel, willMoveTo frame: CGRect)
     
     /// Tells the delegate that the `panel` is moving to a specific position
-    func panel(_ panel: Panel, willMoveTo position: Panel.Configuration.Position)
+    func panel(_ panel: Panel, willMoveFrom oldPosition: Panel.Configuration.Position, to newPosition: Panel.Configuration.Position)
 }
 
 public protocol PanelAccessibilityDelegate: AnyObject {

--- a/Aiolos/Aiolos/Sources/PanelDelegate.swift
+++ b/Aiolos/Aiolos/Sources/PanelDelegate.swift
@@ -28,6 +28,9 @@ public protocol PanelAnimationDelegate: AnyObject {
     /// Tells the delegate that the `panel` is moving to a specific frame
     func panel(_ panel: Panel, willMoveTo frame: CGRect)
     
+    /// Tells the delegate that the `panel` did move to a specific frame
+    func panel(_ panel: Panel, didMoveFrom origin: CGRect, to destination: CGRect, with coordinator: PanelTransitionCoordinator)
+    
     /// Tells the delegate that the `panel` is moving to a specific position
     func panel(_ panel: Panel, willMoveFrom oldPosition: Panel.Configuration.Position, to newPosition: Panel.Configuration.Position, with coordinator: PanelTransitionCoordinator)
 }

--- a/Aiolos/Aiolos/Sources/PanelDelegate.swift
+++ b/Aiolos/Aiolos/Sources/PanelDelegate.swift
@@ -30,6 +30,8 @@ public protocol PanelPositionDelegate: AnyObject {
 
     // TODO: Let the delegate to decide what to do when panel is dragged to a certain offset (either swift side or hide)
     
+    // TODO: Provide `PanelTransitionCoordinator` as a param in `panel(:willMoveFrom:to)` method?
+    
     /// Tells the delegate that the `panel` is moving to a specific frame
     func panel(_ panel: Panel, willMoveTo frame: CGRect)
     

--- a/Aiolos/Aiolos/Sources/PanelGestures.swift
+++ b/Aiolos/Aiolos/Sources/PanelGestures.swift
@@ -149,8 +149,7 @@ private extension PanelGestures {
             let context = PanelTransitionCoordinator.HorizontalTransitionContext(panel: self.panel, parentView: parentView, originalFrame: originalFrame, offset: offset, velocity: velocity)
             self.panel.animator.notifyDelegateOfMove(from: originalFrame, to: self.panel.view.frame, context: context)
 
-            // TODO: compute initial velocity
-            let initialVelocity: CGFloat = 0.0
+            let initialVelocity = self.initialVelocity(with: context)
             let timing = Animation.overdamped.makeTiming(with: initialVelocity)
             self.panel.animator.animateWithTiming(timing, animations: {
                 self.panel.view.transform = .identity
@@ -169,6 +168,22 @@ private extension PanelGestures {
         
         private func cleanUp(pan: UIPanGestureRecognizer) {
             self.gestures.updateResizeHandle()
+        }
+        
+        private func initialVelocity(with context: PanelTransitionCoordinator.HorizontalTransitionContext) -> CGFloat {
+            // FIXME: We assume that the delegate will move the panel to the other side based on the 'context.targetPosition' property
+            let originalPosition = self.panel.configuration.position
+            let targetPosition = context.targetPosition
+            
+            let distance: CGFloat
+            if originalPosition != targetPosition {
+                // Let's assume that the panel is moving across the bounds of the parent view
+                distance = context.parentView.bounds.width - abs(context.offset)
+            } else {
+                distance = context.offset
+            }
+            
+            return abs(context.velocity / distance)
         }
     }
 }

--- a/Aiolos/Aiolos/Sources/PanelGestures.swift
+++ b/Aiolos/Aiolos/Sources/PanelGestures.swift
@@ -212,7 +212,6 @@ private extension PanelGestures {
         }
         
         func handlePanCancelled(_ pan: PanGestureRecognizer) {
-            
             self.panel.animator.animateIfNeeded {
                 self.panel.view.transform = .identity
             }

--- a/Aiolos/Aiolos/Sources/PanelGestures.swift
+++ b/Aiolos/Aiolos/Sources/PanelGestures.swift
@@ -132,7 +132,7 @@ private extension PanelGestures {
             let translation = pan.translation(in: parentView)
             let transformation = CGAffineTransform(translationX: translation.x, y: 0)
             let targetFrame = self.panel.view.frame.applying(transformation)
-            let moveAllowed = self.panel.animator.notifyDelegateAboutMove(to: targetFrame)
+            let moveAllowed = self.panel.animator.askDelegateAboutMove(to: targetFrame)
             let xOffset = dragOffset(for: translation, moveAllowed: moveAllowed)
             guard xOffset != 0.0 else { return }
             

--- a/Aiolos/Aiolos/Sources/PanelGestures.swift
+++ b/Aiolos/Aiolos/Sources/PanelGestures.swift
@@ -62,7 +62,7 @@ final class PanelGestures: NSObject {
     func configure(with configuration: Panel.Configuration) {
         self.cancel()
         self.isVerticalPanEnabled = configuration.gestureResizingMode != .disabled
-        self.isHorizontalPanEnabled = configuration.gesturePositioningMode != .disabled
+        self.isHorizontalPanEnabled = configuration.horizontalPositioningEnabled
     }
 
     func cancel() {

--- a/Aiolos/Aiolos/Sources/PanelGestures.swift
+++ b/Aiolos/Aiolos/Sources/PanelGestures.swift
@@ -148,10 +148,13 @@ private extension PanelGestures {
             let velocity = pan.velocity(in: parentView).x
             let context = PanelTransitionCoordinator.HorizontalTransitionContext(panel: self.panel, parentView: parentView, originalFrame: originalFrame, offset: offset, velocity: velocity)
             self.panel.animator.notifyDelegateOfMove(from: originalFrame, to: self.panel.view.frame, context: context)
-            
-            self.panel.animator.animateIfNeeded {
+
+            // TODO: compute initial velocity
+            let initialVelocity: CGFloat = 0.0
+            let timing = Animation.overdamped.makeTiming(with: initialVelocity)
+            self.panel.animator.animateWithTiming(timing, animations: {
                 self.panel.view.transform = .identity
-            }
+            })
             
             self.cleanUp(pan: pan)
         }

--- a/Aiolos/Aiolos/Sources/PanelGestures.swift
+++ b/Aiolos/Aiolos/Sources/PanelGestures.swift
@@ -158,9 +158,7 @@ private extension PanelGestures {
             let velocity = pan.velocity(in: parentView).x
             let context = PanelTransitionCoordinator.HorizontalTransitionContext(panel: self.panel, parentView: parentView, originalFrame: originalFrame, offset: offset, velocity: velocity)
             
-            // TODO: Ask the delegate what to do
-//            let instruction = self.panel.animator.notifyDelegateOfMove(from: originalFrame, to: self.panel.view.frame, context: context)
-            let instruction: PanelTransitionCoordinator.Instruction = .none
+            let instruction = self.panel.animator.askDelegateOfMove(from: originalFrame, to: self.panel.view.frame, context: context)
             
             switch instruction {
             case .none:

--- a/Aiolos/Aiolos/Sources/PanelGestures.swift
+++ b/Aiolos/Aiolos/Sources/PanelGestures.swift
@@ -125,14 +125,14 @@ private extension PanelGestures {
         }
         
         func handlePanChanged(_ pan: PanGestureRecognizer) {
-            guard let superview = self.panel.view.superview else { return }
+            guard let parentView = self.panel.parent?.view else { return }
             
             func dragOffset(for translation: CGPoint, moveAllowed: Bool) -> CGFloat {
                 let dragCoefficient: CGFloat = 1/5 // TODO: revise
                 return moveAllowed ? translation.x : translation.x * dragCoefficient
             }
             
-            let translation = pan.translation(in: superview)
+            let translation = pan.translation(in: parentView)
             let transformation = CGAffineTransform(translationX: translation.x, y: 0)
             let targetFrame = self.panel.view.frame.applying(transformation)
             let moveAllowed = self.panel.animator.askDelegateOfMove(to: targetFrame)
@@ -143,11 +143,13 @@ private extension PanelGestures {
         }
         
         func handlePanEnded(_ pan: PanGestureRecognizer) {
+            guard let parentView = self.panel.parent?.view else { return }
+            
             // The view is being transformed, thus the frame changes while dragging, hence the correction
             let originalFrame = self.panel.view.frame.applying(self.panel.view.transform.inverted())
-            let offset = pan.translation(in: self.panel.view).x
-            let velocity = pan.velocity(in: self.panel.view).x
-            let context = PanelTransitionCoordinator.HorizontalTransitionContext(panel: self.panel, originalFrame: originalFrame, offset: offset, velocity: velocity)
+            let offset = pan.translation(in: parentView).x
+            let velocity = pan.velocity(in: parentView).x
+            let context = PanelTransitionCoordinator.HorizontalTransitionContext(panel: self.panel, parentView: parentView, originalFrame: originalFrame, offset: offset, velocity: velocity)
             self.panel.animator.notifyDelegateOfDidMove(from: originalFrame, to: self.panel.view.frame, context: context)
             
             self.panel.animator.animateIfNeeded {

--- a/Aiolos/Aiolos/Sources/PanelGestures.swift
+++ b/Aiolos/Aiolos/Sources/PanelGestures.swift
@@ -550,7 +550,7 @@ private extension PanelGestures {
         let pan = PanGestureRecognizer(target: self.horizontalHandler, action: #selector(HorizontalHandler.handlePan))
         pan.panDirection = .horizontal
         pan.delegate = self
-        pan.cancelsTouchesInView = false
+        pan.cancelsTouchesInView = true
         return pan
     }
 

--- a/Aiolos/Aiolos/Sources/PanelGestures.swift
+++ b/Aiolos/Aiolos/Sources/PanelGestures.swift
@@ -232,13 +232,20 @@ private extension PanelGestures {
         // TODO: Debug
         self.debugShowProjectedView(projectedOffset: projectedOffset)
         
-        if projectedOffset < -threshold {
+        // TODO: Support move to .bottom for iPad?
+        let supportedPositions = self.panel.configuration.supportedPositions
+        
+        // moving towards the leading edge of the screen
+        if projectedOffset < -threshold && supportedPositions.contains(.leadingBottom) {
             return .leadingBottom
-        } else if projectedOffset > threshold {
-            return .trailingBottom
-        } else {
-            return self.panel.configuration.position // Original position
         }
+        
+        // moving towards the trailing edge of the screen
+        if projectedOffset > threshold && supportedPositions.contains(.trailingBottom) {
+            return .trailingBottom
+        }
+        
+        return self.panel.configuration.position // Original position
     }
     
     func handleHorizontalPanCancelled(_ pan: PanGestureRecognizer) {

--- a/Aiolos/Aiolos/Sources/PanelGestures.swift
+++ b/Aiolos/Aiolos/Sources/PanelGestures.swift
@@ -161,7 +161,7 @@ private extension PanelGestures {
                 self.panel.view.transform = .identity
             }
             
-            cleanUpAfterHorizontalPan(pan)
+            self.cleanUpAfterHorizontalPan(pan)
         }
         
         func cleanUpAfterHorizontalPan(_ pan: PanGestureRecognizer) {

--- a/Aiolos/Aiolos/Sources/PanelGestures.swift
+++ b/Aiolos/Aiolos/Sources/PanelGestures.swift
@@ -536,9 +536,3 @@ private extension UIGestureRecognizer {
         self.isEnabled = true
     }
 }
-
-// Inspired by: https://medium.com/ios-os-x-development/gestures-in-fluid-interfaces-on-intent-and-projection-36d158db7395
-private func project(_ velocity: CGFloat, onto position: CGFloat, decelerationRate: UIScrollView.DecelerationRate = .normal) -> CGFloat {
-    let factor = -1 / (1000 * log(decelerationRate.rawValue))
-    return position + factor * velocity
-}

--- a/Aiolos/Aiolos/Sources/PanelGestures.swift
+++ b/Aiolos/Aiolos/Sources/PanelGestures.swift
@@ -95,7 +95,7 @@ extension PanelGestures: UIGestureRecognizerDelegate {
 
 private extension PanelGestures {
 
-    final class HorizontalHandler: NSObject {
+    final class HorizontalHandler {
         
         private unowned let gestures: PanelGestures
         private var panel: Panel { return gestures.panel }
@@ -168,7 +168,7 @@ private extension PanelGestures {
         }
     }
     
-    final class VerticalHandler: NSObject {
+    final class VerticalHandler {
         
         private unowned let gestures: PanelGestures
         private var panel: Panel { return gestures.panel }

--- a/Aiolos/Aiolos/Sources/PanelGestures.swift
+++ b/Aiolos/Aiolos/Sources/PanelGestures.swift
@@ -15,7 +15,7 @@ final class PanelGestures: NSObject {
     private unowned let panel: Panel
     private var originalConfiguration: PanelGestures.Configuration?
     private lazy var pan: PanGestureRecognizer = self.makeVerticalPanGestureRecognizer()
-    private lazy var horizontalPan: UIPanGestureRecognizer = self.makeHorizontalPanGestureRecognizer()
+    private lazy var horizontalPan: PanGestureRecognizer = self.makeHorizontalPanGestureRecognizer()
     
     // TODO: Delete once the implementation is finished
     private weak var middleLine: UIView?
@@ -70,7 +70,6 @@ extension PanelGestures: UIGestureRecognizerDelegate {
     }
 
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
-        // TODO: Make the panel move either way but not both at the same time
         return true
     }
 
@@ -105,13 +104,15 @@ private extension PanelGestures {
 
     func makeVerticalPanGestureRecognizer() -> PanGestureRecognizer {
         let pan = PanGestureRecognizer(target: self, action: #selector(handlePan))
+        pan.panDirection = .vertical
         pan.delegate = self
         pan.cancelsTouchesInView = false
         return pan
     }
     
-    func makeHorizontalPanGestureRecognizer() -> UIPanGestureRecognizer {
-        let pan = UIPanGestureRecognizer(target: self, action: #selector(handleHorizontalPan))
+    func makeHorizontalPanGestureRecognizer() -> PanGestureRecognizer {
+        let pan = PanGestureRecognizer(target: self, action: #selector(handleHorizontalPan))
+        pan.panDirection = .horizontal
         pan.delegate = self
         pan.cancelsTouchesInView = false
         return pan
@@ -138,7 +139,7 @@ private extension PanelGestures {
     }
     
     @objc
-    func handleHorizontalPan(_ pan: UIPanGestureRecognizer) {
+    func handleHorizontalPan(_ pan: PanGestureRecognizer) {
         // TODO: Inform the delegate when moving to the new position
         
         let translation = pan.translation(in: self.panel.view)

--- a/Aiolos/Aiolos/Sources/PanelGestures.swift
+++ b/Aiolos/Aiolos/Sources/PanelGestures.swift
@@ -140,7 +140,6 @@ private extension PanelGestures {
             guard xOffset != 0.0 else { return }
             
             self.panel.animator.performWithoutAnimation { self.panel.view.transform = CGAffineTransform(translationX: xOffset, y: 0) }
-            self.panel.animator.notifyDelegateOfWillMove(to: self.panel.view.frame)
         }
         
         func handlePanEnded(_ pan: PanGestureRecognizer) {

--- a/Aiolos/Aiolos/Sources/PanelGestures.swift
+++ b/Aiolos/Aiolos/Sources/PanelGestures.swift
@@ -488,10 +488,6 @@ private extension PanelGestures {
         self.verticalPan.cancel()
     }
     
-    func cancelHorizontalPan() {
-        self.horizontalPan.cancel()
-    }
-    
     func updateResizeHandle() {
         self.panel.resizeHandle.isResizing = self.isPanning
     }

--- a/Aiolos/Aiolos/Sources/PanelGestures.swift
+++ b/Aiolos/Aiolos/Sources/PanelGestures.swift
@@ -104,7 +104,7 @@ private extension PanelGestures {
         
         func shouldStartPan(_ pan: UIPanGestureRecognizer) -> Bool {
             let velocity = pan.velocity(in: self.panel.view)
-            let isPanningHorizontally = abs(velocity.x) > 3 * abs(velocity.y)
+            let isPanningHorizontally = abs(velocity.x) > 1.5 * abs(velocity.y)
             guard isPanningHorizontally else { return false }
             guard let contentViewController = self.panel.contentViewController else { return true }
 

--- a/Aiolos/Aiolos/Sources/PanelGestures.swift
+++ b/Aiolos/Aiolos/Sources/PanelGestures.swift
@@ -171,17 +171,14 @@ private extension PanelGestures {
     }
     
     func handleHorizontalPanChanged(_ pan: PanGestureRecognizer) {
-        
         guard let superview = self.panel.view.superview else { return }
         
-        let translation = pan.translation(in: superview)
-        
         func dragOffset(for translation: CGPoint) -> CGFloat {
-            // TODO: Avoid the panel being dragged over the edge of the screen
-            // TODO: Real implementation
+            // TODO: Avoid the panel being dragged over the edge of the screen (if not allowed)
             return translation.x
         }
 
+        let translation = pan.translation(in: superview)
         let xOffset = dragOffset(for: translation)
         guard xOffset != 0.0 else { return }
         
@@ -235,6 +232,7 @@ private extension PanelGestures {
         // TODO: Support move to .bottom for iPad?
         let supportedPositions = self.panel.configuration.supportedPositions
         
+        // FIXME: Support right-to-left languages (leading and trailing is swapped)
         // moving towards the leading edge of the screen
         if projectedOffset < -threshold && supportedPositions.contains(.leadingBottom) {
             return .leadingBottom

--- a/Aiolos/Aiolos/Sources/PanelGestures.swift
+++ b/Aiolos/Aiolos/Sources/PanelGestures.swift
@@ -43,8 +43,8 @@ final class PanelGestures: NSObject {
     // MARK: - PanelGestures
 
     func install() {
-        // Limit the gesture to only trigger, when it is started on top of the resize handle
-        self.panel.resizeHandle.addGestureRecognizer(self.pan)
+        self.panel.view.addGestureRecognizer(self.pan)
+        // Limit the horizontal gesture to only trigger, when it is started on top of the resize handle
         self.panel.resizeHandle.addGestureRecognizer(self.horizontalPan)
     }
 

--- a/Aiolos/Aiolos/Sources/PanelGestures.swift
+++ b/Aiolos/Aiolos/Sources/PanelGestures.swift
@@ -214,9 +214,8 @@ private extension PanelGestures {
         private func offset(for position: Panel.Configuration.Position) -> CGFloat {
             let originalPosition = self.panel.configuration.position
             guard originalPosition != position else { return 0 }
-            guard let parentView = self.panel.parent?.view else { return 0 }
             
-            let isRTL = parentView.effectiveUserInterfaceLayoutDirection == .rightToLeft
+            let isRTL = self.panel.view.effectiveUserInterfaceLayoutDirection == .rightToLeft
             let distance = self.panel.constraints.effectiveBounds.width - self.panel.view.frame.width
             switch position {
             case .leadingBottom:

--- a/Aiolos/Aiolos/Sources/PanelGestures.swift
+++ b/Aiolos/Aiolos/Sources/PanelGestures.swift
@@ -62,6 +62,10 @@ extension PanelGestures: UIGestureRecognizerDelegate {
     func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
         switch gestureRecognizer {
         case self.horizontalPan:
+            // The vertical PanGestureRecognizer starts without any delay so we need to ensure
+            // it hasn't changed before allowing the horizontal gesture recognizer to start.
+            guard self.verticalPan.state != .changed else { return false }
+            
             return self.horizontalHandler.shouldStartPan(self.horizontalPan)
         case self.verticalPan:
             return self.verticalHandler.shouldStartPan(self.verticalPan)

--- a/Aiolos/Aiolos/Sources/PanelGestures.swift
+++ b/Aiolos/Aiolos/Sources/PanelGestures.swift
@@ -187,8 +187,8 @@ private extension PanelGestures {
             
             let distance: CGFloat
             if originalPosition != targetPosition {
-                // Let's assume that the panel is moving across the bounds of the parent view
-                distance = context.parentView.bounds.width - abs(context.offset)
+                // Let's assume that the panel is moving across the parent view's safe area
+                distance = context.parentView.bounds.width - context.parentView.safeAreaInsets.left - context.parentView.safeAreaInsets.right - panel.view.bounds.width - abs(context.offset)
             } else {
                 distance = context.offset
             }

--- a/Aiolos/Aiolos/Sources/PanelGestures.swift
+++ b/Aiolos/Aiolos/Sources/PanelGestures.swift
@@ -127,13 +127,16 @@ private extension PanelGestures {
         func handlePanChanged(_ pan: PanGestureRecognizer) {
             guard let superview = self.panel.view.superview else { return }
             
-            func dragOffset(for translation: CGPoint) -> CGFloat {
-                // TODO: Avoid the panel being dragged over the edge of the screen (if not allowed - ask the delegate)
-                return translation.x
+            func dragOffset(for translation: CGPoint, moveAllowed: Bool) -> CGFloat {
+                let dragCoefficient: CGFloat = 1/5 // TODO: revise
+                return moveAllowed ? translation.x : translation.x * dragCoefficient
             }
             
             let translation = pan.translation(in: superview)
-            let xOffset = dragOffset(for: translation)
+            let transformation = CGAffineTransform(translationX: translation.x, y: 0)
+            let targetFrame = self.panel.view.frame.applying(transformation)
+            let moveAllowed = self.panel.animator.askDelegateOfMove(to: targetFrame)
+            let xOffset = dragOffset(for: translation, moveAllowed: moveAllowed)
             guard xOffset != 0.0 else { return }
             
             self.panel.animator.performWithoutAnimation { self.panel.view.transform = CGAffineTransform(translationX: xOffset, y: 0) }

--- a/Aiolos/Aiolos/Sources/PanelGestures.swift
+++ b/Aiolos/Aiolos/Sources/PanelGestures.swift
@@ -145,8 +145,10 @@ private extension PanelGestures {
         func handlePanEnded(_ pan: PanGestureRecognizer) {
             // The view is being transformed, thus the frame changes while dragging, hence the correction
             let originalFrame = self.panel.view.frame.applying(self.panel.view.transform.inverted())
-            
-            self.panel.animator.notifyDelegateOfDidMove(from: originalFrame, to: self.panel.view.frame, pan: pan)
+            let offset = pan.translation(in: self.panel.view).x
+            let velocity = pan.velocity(in: self.panel.view).x
+            let context = PanelTransitionCoordinator.HorizontalTransitionContext(panel: self.panel, originalFrame: originalFrame, offset: offset, velocity: velocity)
+            self.panel.animator.notifyDelegateOfDidMove(from: originalFrame, to: self.panel.view.frame, context: context)
             
             self.panel.animator.animateIfNeeded {
                 self.panel.view.transform = .identity

--- a/Aiolos/Aiolos/Sources/PanelGestures.swift
+++ b/Aiolos/Aiolos/Sources/PanelGestures.swift
@@ -13,13 +13,11 @@ import Foundation
 final class PanelGestures: NSObject {
 
     private unowned let panel: Panel
-    private var originalConfiguration: PanelGestures.Configuration?
     
     private lazy var verticalPan: PanGestureRecognizer = self.makeVerticalPanGestureRecognizer()
     private lazy var horizontalPan: PanGestureRecognizer = self.makeHorizontalPanGestureRecognizer()
-    
-    // TODO: Delete once the implementation is finished
-    private weak var middleLine: UIView?
+    private lazy var verticalHandler: VerticalHandler = VerticalHandler(gestures: self)
+    private lazy var horizontalHandler: HorizontalHandler = HorizontalHandler(gestures: self)
     
     private var isVerticalPanEnabled: Bool {
         get { return self.verticalPan.isEnabled }
@@ -78,8 +76,8 @@ extension PanelGestures: UIGestureRecognizerDelegate {
     func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
         guard let contentViewController = self.panel.contentViewController else { return true }
 
-        return self.gestureRecognizer(gestureRecognizer, isWithinContentAreaOf: contentViewController) == false ||
-            self.gestureRecognizer(gestureRecognizer, isAllowedToStartByContentOf: contentViewController)
+        return self.verticalHandler.gestureRecognizer(gestureRecognizer, isWithinContentAreaOf: contentViewController) == false ||
+            self.verticalHandler.gestureRecognizer(gestureRecognizer, isAllowedToStartByContentOf: contentViewController)
     }
 
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
@@ -97,6 +95,431 @@ extension PanelGestures: UIGestureRecognizerDelegate {
 
 private extension PanelGestures {
 
+    final class HorizontalHandler: NSObject {
+        
+        private unowned let gestures: PanelGestures
+        private var panel: Panel { return gestures.panel }
+        private weak var middleLine: UIView? // TODO: Delete once the implementation is finished
+        
+        init(gestures: PanelGestures) {
+            self.gestures = gestures
+        }
+        
+        @objc
+        func handlePan(_ pan: PanGestureRecognizer) {
+            switch pan.state {
+            case .began:
+                self.handlePanStarted(pan)
+            case .changed:
+                self.handlePanChanged(pan)
+            case .ended:
+                self.handlePanEnded(pan)
+            case .cancelled:
+                self.handlePanCancelled(pan)
+            default:
+                break
+            }
+        }
+        
+        func handlePanStarted(_ pan: PanGestureRecognizer) {
+            self.gestures.updateResizeHandle()
+            
+            // TODO: Debug
+            guard let superview = self.panel.view.superview else { return }
+            let midScreen = superview.bounds.midX
+            self.debugShowMiddleLine(at: midScreen)
+        }
+        
+        func handlePanChanged(_ pan: PanGestureRecognizer) {
+            guard let superview = self.panel.view.superview else { return }
+            
+            func dragOffset(for translation: CGPoint) -> CGFloat {
+                // TODO: Avoid the panel being dragged over the edge of the screen (if not allowed)
+                return translation.x
+            }
+            
+            let translation = pan.translation(in: superview)
+            let xOffset = dragOffset(for: translation)
+            guard xOffset != 0.0 else { return }
+            
+            self.panel.animator.performWithoutAnimation { self.panel.view.transform = CGAffineTransform(translationX: xOffset, y: 0) }
+            self.panel.animator.notifyDelegateOfMove(to: self.panel.view.frame)
+            
+            // TODO: Debug
+            let midScreen = superview.bounds.midX
+            /// Calculate how large xOffset must be to reach the middle of the screen from the closer edge
+            /// - NOTE: The view is being transformed, thus the frame changes while dragging, hence the correction
+            let originalFrame = self.panel.view.frame.applying(self.panel.view.transform.inverted())
+            let threshold = min(abs(midScreen - originalFrame.maxX), abs(midScreen - originalFrame.minX))
+            self.debugUpdateMiddleLine(withOffset: xOffset, threshold: threshold)
+        }
+        
+        func handlePanEnded(_ pan: PanGestureRecognizer) {
+            guard let parentView = self.panel.parent?.view else { return }
+            
+            let originalPosition = self.panel.configuration.position
+            let targetPosition = self.targetPosition(for: pan, parentView: parentView)
+            let projectedOffset = self.projectedOffset(for: pan)
+            
+            self.panel.animator.notifyDelegateOfMove(from: originalPosition, to: targetPosition)
+            self.animate(to: targetPosition, projectedOffset: projectedOffset)
+            self.cleanUpAfterHorizontalPan(pan)
+        }
+        
+        func projectedOffset(for pan: PanGestureRecognizer) -> CGFloat {
+            let velocity = pan.velocity(in: self.panel.view)
+            let translation = pan.translation(in: self.panel.view)
+            
+            return project(velocity.x, onto: translation.x)
+        }
+        
+        func targetPosition(for pan: PanGestureRecognizer, parentView: UIView) -> Panel.Configuration.Position {
+            
+            // When an edge of the panel is over the middle of the screen -> activate the move to the other side.
+            // Velocity is taken into account to calculate projection -> allow flicking the panel.
+            // FIXME: Better animation of the momevent to the target position (same as the Slide Over mode on iPad)
+            
+            let supportedPositions = self.panel.configuration.supportedPositions
+            let originalPosition = self.panel.configuration.position
+            let projectedOffset = self.projectedOffset(for: pan)
+            let delta = abs(projectedOffset)
+            let originalFrame = self.panel.view.frame.applying(self.panel.view.transform.inverted())
+            let midScreen = parentView.bounds.midX
+            /// Calculate how large xOffset must be to reach the middle of the screen from the closer edge
+            /// - NOTE: The view is being transformed, thus the frame changes while dragging, hence the correction
+            let threshold = min(abs(midScreen - originalFrame.maxX), abs(midScreen - originalFrame.minX))
+            
+            // TODO: Debug
+            self.debugShowProjectedView(projectedOffset: projectedOffset)
+            
+            // TODO: Support move to .bottom for iPad?
+            let isRTL = UIView.userInterfaceLayoutDirection(for: parentView.semanticContentAttribute) == .rightToLeft
+            let normalizedProjectedOffset = (isRTL ? -1 : 1) * projectedOffset
+            let isMovingTowardsLeadingEdge = normalizedProjectedOffset < 0
+            let isMovingTowardsTrailingEdge = normalizedProjectedOffset > 0
+            
+            guard delta > threshold else { return originalPosition }
+            
+            if isMovingTowardsLeadingEdge && supportedPositions.contains(.leadingBottom) {
+                return .leadingBottom
+            }
+            
+            if isMovingTowardsTrailingEdge && supportedPositions.contains(.trailingBottom) {
+                return .trailingBottom
+            }
+            
+            return originalPosition
+        }
+        
+        func handlePanCancelled(_ pan: PanGestureRecognizer) {
+            
+            self.panel.animator.animateIfNeeded {
+                self.panel.view.transform = .identity
+            }
+            
+            cleanUpAfterHorizontalPan(pan)
+        }
+        
+        func cleanUpAfterHorizontalPan(_ pan: PanGestureRecognizer) {
+            self.gestures.updateResizeHandle()
+            
+            // TODO: Debug
+            self.middleLine?.removeFromSuperview()
+        }
+        
+        func animate(to targetPosition: Panel.Configuration.Position, projectedOffset: CGFloat) {
+            // TODO: Take projected offset into account and "overshoot" the animation
+            self.panel.animator.animateIfNeeded {
+                self.panel.view.transform = .identity
+                self.panel.configuration.position = targetPosition
+            }
+        }
+    }
+    
+    final class VerticalHandler: NSObject {
+        
+        private unowned let gestures: PanelGestures
+        private var panel: Panel { return gestures.panel }
+        private var originalConfiguration: PanelGestures.Configuration?
+        
+        init(gestures: PanelGestures) {
+            self.gestures = gestures
+        }
+        
+        @objc
+        func handlePan(_ pan: PanGestureRecognizer) {
+            switch pan.state {
+            case .began:
+                self.handlePanStarted(pan)
+            case .changed:
+                self.handlePanChanged(pan)
+            case .ended:
+                self.handlePanEnded(pan)
+            case .cancelled:
+                self.handlePanCancelled(pan)
+            default:
+                break
+            }
+        }
+        
+        func handlePanStarted(_ pan: PanGestureRecognizer) {
+            let configuration = PanelGestures.Configuration(mode: self.panel.configuration.mode,
+                                                            animateChanges: self.panel.animator.animateChanges)
+            // remember initial state
+            self.originalConfiguration = configuration
+            
+            if let contentViewController = self.panel.contentViewController {
+                if self.gestureRecognizer(pan, isWithinContentAreaOf: contentViewController), let scrollView = self.verticallyScrollableView(of: contentViewController, interactingWith: pan) {
+                    pan.startMode = .onVerticallyScrollableArea(competingScrollView: scrollView)
+                } else {
+                    pan.startMode = .onFixedArea
+                }
+            }
+        }
+        
+        func handlePanDragStart(_ pan: PanGestureRecognizer) -> Bool {
+            self.panel.animator.animateChanges = false
+            self.panel.animator.performWithoutAnimation {
+                self.panel.constraints.updateForPanStart(with: self.panel.view.frame.size)
+            }
+            
+            pan.cancelsTouchesInView = true
+            self.gestures.updateResizeHandle()
+            
+            let velocity = pan.velocity(in: self.panel.view)
+            
+            if case .onVerticallyScrollableArea(let scrollView) = pan.startMode {
+                if velocity.y < 0.0 {
+                    // if the gesture scrolls the content, cancel the resizing gesture itself
+                    self.gestures.cancelVerticalPan()
+                    return false
+                } else if velocity.y > 0.0 {
+                    // if the gesture would shrink the panel, cancel all gestures on the competing scrollView
+                    scrollView.gestureRecognizers?.forEach {
+                        $0.cancel()
+                    }
+                }
+            }
+            
+            return true
+        }
+        
+        func handlePanChanged(_ pan: PanGestureRecognizer) {
+            guard let parentView = self.panel.parent?.view else { return }
+            
+            func dragOffset(for translation: CGPoint) -> CGFloat {
+                let fudgeFactor: CGFloat = 60.0
+                let minHeight = self.height(for: .compact) + fudgeFactor
+                let maxHeight = self.panel.constraints.maxHeight - fudgeFactor
+                let currentHeight = self.currentPanelHeight
+                
+                // slow down resizing if the current height exceeds certain limits
+                let isNearingEdge = (currentHeight < minHeight && translation.y > 0.0) || (currentHeight > maxHeight && translation.y < 0.0)
+                let isShrinkingOnScrollView = pan.startMode != .onFixedArea && translation.y > 0.0
+                if isNearingEdge || isShrinkingOnScrollView {
+                    return translation.y / 3.0
+                } else {
+                    return translation.y
+                }
+            }
+            
+            let translation = pan.translation(in: self.panel.view)
+            let yOffset = dragOffset(for: translation)
+            guard yOffset != 0.0 else { return }
+            
+            pan.setTranslation(.zero, in: self.panel.view)
+            if pan.didPan && pan.cancelsTouchesInView == false {
+                guard self.handlePanDragStart(pan) else { return }
+            }
+            
+            self.panel.animator.performWithoutAnimation { self.panel.constraints.updateForPan(with: yOffset) }
+            self.panel.animator.notifyDelegateOfTransition(to: CGSize(width: self.panel.view.frame.width, height: self.currentPanelHeight))
+        }
+        
+        func handlePanEnded(_ pan: PanGestureRecognizer) {
+            guard let originalMode = self.originalConfiguration?.mode else { return }
+            
+            self.panel.constraints.updateForPanEnd()
+            guard pan.didPan || originalMode == .minimal else {
+                self.handlePanCancelled(pan)
+                return
+            }
+            
+            let targetMode = self.targetMode(for: pan)
+            let initialVelocity = self.initialVelocity(for: pan, targetMode: targetMode)
+            
+            self.animate(to: targetMode, initialVelocity: initialVelocity)
+            self.cleanUp(pan: pan)
+        }
+        
+        func handlePanCancelled(_ pan: PanGestureRecognizer) {
+            guard let originalMode = self.originalConfiguration?.mode else { return }
+            
+            let currentHeight = self.currentPanelHeight
+            self.cleanUp(pan: pan)
+            
+            let size = self.panel.size(for: originalMode)
+            self.panel.animator.notifyDelegateOfTransition(from: originalMode, to: originalMode)
+            self.panel.constraints.updateForPanCancelled(with: size)
+            if currentHeight != size.height {
+                self.panel.animator.notifyDelegateOfTransition(to: size)
+            }
+        }
+        
+        // swiftlint:disable cyclomatic_complexity
+        func targetMode(for pan: PanGestureRecognizer) -> Panel.Configuration.Mode {
+            let supportedModes = self.panel.configuration.supportedModes
+            guard let originalConfiguration = self.originalConfiguration else { return supportedModes.first! }
+            
+            let offset: CGFloat = 100.0
+            let minVelocity: CGFloat = 20.0
+            let velocity = pan.velocity(in: self.panel.view).y
+            let heightCompact = self.height(for: .compact)
+            let heightExpanded = self.height(for: .expanded)
+            let currentHeight = self.currentPanelHeight
+            
+            let isMovingUpwards = velocity < -minVelocity
+            let isMovingDownwards = velocity > minVelocity
+            
+            // expand to .compact if we "tap" on .minimal
+            if isMovingUpwards == false && isMovingDownwards == false && originalConfiguration.mode == .minimal && currentHeight < heightCompact && supportedModes.contains(.compact) {
+                return .compact
+            }
+            // .minimal is only allowed when moving downwards from .compact
+            if isMovingDownwards && originalConfiguration.mode == .compact && currentHeight < heightCompact && supportedModes.contains(.minimal) {
+                return .minimal
+            }
+            // if we move up from .minimal we have a higher threshold for .expanded and prefer .compact
+            if isMovingUpwards && originalConfiguration.mode == .minimal && currentHeight < heightCompact + 40.0 && supportedModes.contains(.compact) {
+                return .compact
+            }
+            // moving upwards + current size > .expanded -> grow to .fullHeight
+            if currentHeight >= heightExpanded && isMovingUpwards && supportedModes.contains(.fullHeight) {
+                return .fullHeight
+            }
+            // moving downwards + current size < .expanded -> shrink to .collapsed
+            if currentHeight <= heightExpanded && isMovingDownwards && supportedModes.contains(.compact) {
+                return .compact
+            }
+            // moving upwards + current size < .expanded -> grow to .expanded
+            if currentHeight <= heightExpanded && isMovingUpwards {
+                if supportedModes.contains(.expanded) { return .expanded }
+                if supportedModes.contains(.fullHeight) { return .fullHeight }
+            }
+            // moving downwards + current size > .expanded -> shrink to .expanded
+            if currentHeight >= heightExpanded && isMovingDownwards {
+                if supportedModes.contains(.expanded) { return .expanded }
+                if supportedModes.contains(.compact) { return .compact }
+            }
+            
+            // check distance from .expanded mode
+            let diffToExpanded = currentHeight - heightExpanded
+            
+            if diffToExpanded > offset && supportedModes.contains(.fullHeight) {
+                return .fullHeight
+            } else if diffToExpanded < -offset && supportedModes.contains(.compact) {
+                return .compact
+            } else if supportedModes.contains(.expanded) {
+                return .expanded
+            } else {
+                return originalConfiguration.mode
+            }
+        }
+        // swiftlint:enable cyclomatic_complexity
+        
+        func cleanUp(pan: PanGestureRecognizer) {
+            pan.cancelsTouchesInView = false
+            
+            guard let originalConfiguration = self.originalConfiguration else { return }
+            
+            self.gestures.updateResizeHandle()
+            self.panel.animator.animateChanges = originalConfiguration.animateChanges
+            self.originalConfiguration = nil
+        }
+        
+        func height(for mode: Panel.Configuration.Mode) -> CGFloat {
+            if mode == .fullHeight {
+                return self.panel.constraints.maxHeight
+            } else {
+                return self.panel.size(for: mode).height
+            }
+        }
+        
+        func initialVelocity(for pan: PanGestureRecognizer, targetMode: Panel.Configuration.Mode) -> CGFloat {
+            let velocity = pan.velocity(in: self.panel.view).y
+            let currentHeight = self.currentPanelHeight
+            let targetHeight = self.height(for: targetMode)
+            
+            let distance = targetHeight - currentHeight
+            return abs(velocity / distance)
+        }
+        
+        func timing(for initialVelocity: CGFloat) -> UITimingCurveProvider {
+            let springTiming = Animation.springy.makeTiming(with: initialVelocity)
+            guard let originalConfiguration = self.originalConfiguration else { return springTiming }
+            
+            if originalConfiguration.mode == .minimal || initialVelocity < 13.0 {
+                return Animation.overdamped.makeTiming(with: initialVelocity)
+            } else {
+                return springTiming
+            }
+        }
+        
+        func animate(to targetMode: Panel.Configuration.Mode, initialVelocity: CGFloat) {
+            let height = self.height(for: targetMode)
+            let size = self.panel.size(for: targetMode)
+            let timing = self.timing(for: initialVelocity)
+            
+            self.panel.constraints.prepareForPanEndAnimation()
+            self.panel.configuration.mode = targetMode
+            self.panel.animator.animateWithTiming(timing, animations: {
+                self.panel.constraints.updateForPanEndAnimation(to: height)
+                self.panel.animator.notifyDelegateOfTransition(to: size)
+                self.panel.fixNavigationBarLayoutMargins()
+            }, completion: {
+                self.panel.constraints.updateSizeConstraints(for: size)
+            })
+        }
+        
+        // allow pan gestures to be triggered within non-safe area on top (UINavigationBar)
+        func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, isWithinContentAreaOf contentViewController: UIViewController) -> Bool {
+            let offset: CGFloat = 10.0
+            let safeAreaTop: CGFloat
+            if let navigationController = contentViewController as? UINavigationController {
+                safeAreaTop = navigationController.navigationBar.frame.maxY + offset
+            } else {
+                safeAreaTop = offset
+            }
+            
+            let location = gestureRecognizer.location(in: self.panel.panelView)
+            return location.y >= safeAreaTop
+        }
+        
+        // allow pan gesture to be triggered when a) there's no scrollView or b) the scrollView can't be scrolled downwards
+        func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, isAllowedToStartByContentOf contentViewController: UIViewController) -> Bool {
+            guard self.panel.configuration.gestureResizingMode == .includingContent else { return false }
+            
+            guard let enclosingScrollView = self.verticallyScrollableView(of: contentViewController, interactingWith: gestureRecognizer) else { return true }
+            // don't allow resizing gesture if textView is currently text editing
+            if let textView = enclosingScrollView as? UITextView, textView.isFirstResponder {
+                return false
+            }
+            
+            return enclosingScrollView.isScrolledToTop
+        }
+        
+        func verticallyScrollableView(of contentViewController: UIViewController, interactingWith gestureRecognizer: UIGestureRecognizer) -> UIScrollView? {
+            let location = gestureRecognizer.location(in: contentViewController.view)
+            guard let hitView = contentViewController.view.hitTest(location, with: nil) else { return nil }
+            
+            return hitView.findFirstSuperview(ofClass: UIScrollView.self, where: { $0.scrollsVertically })
+        }
+        
+        var currentPanelHeight: CGFloat {
+            return self.panel.constraints.heightConstraint!.constant
+        }
+    }
+    
     struct Configuration {
         let mode: Panel.Configuration.Mode
         let animateChanges: Bool
@@ -116,7 +539,7 @@ private extension PanelGestures {
     }
 
     func makeVerticalPanGestureRecognizer() -> PanGestureRecognizer {
-        let pan = PanGestureRecognizer(target: self, action: #selector(handlePan))
+        let pan = PanGestureRecognizer(target: self.verticalHandler, action: #selector(VerticalHandler.handlePan))
         pan.panDirection = .vertical
         pan.delegate = self
         pan.cancelsTouchesInView = false
@@ -124,7 +547,7 @@ private extension PanelGestures {
     }
     
     func makeHorizontalPanGestureRecognizer() -> PanGestureRecognizer {
-        let pan = PanGestureRecognizer(target: self, action: #selector(handleHorizontalPan))
+        let pan = PanGestureRecognizer(target: self.horizontalHandler, action: #selector(HorizontalHandler.handlePan))
         pan.panDirection = .horizontal
         pan.delegate = self
         pan.cancelsTouchesInView = false
@@ -139,415 +562,8 @@ private extension PanelGestures {
         self.horizontalPan.cancel()
     }
     
-    var currentPanelHeight: CGFloat {
-        return self.panel.constraints.heightConstraint!.constant
-    }
-    
-    // MARK: - Horizontal pan
-    
-    @objc
-    func handleHorizontalPan(_ pan: PanGestureRecognizer) {
-        switch pan.state {
-        case .began:
-            self.handleHorizontalPanStarted(pan)
-        case .changed:
-            self.handleHorizontalPanChanged(pan)
-        case .ended:
-            self.handleHorizontalPanEnded(pan)
-        case .cancelled:
-            self.handleHorizontalPanCancelled(pan)
-        default:
-            break
-        }
-    }
-    
-    func handleHorizontalPanStarted(_ pan: PanGestureRecognizer) {
-        self.updateResizeHandle()
-        
-        // TODO: Debug
-        guard let superview = self.panel.view.superview else { return }
-        let midScreen = superview.bounds.midX
-        self.debugShowMiddleLine(at: midScreen)
-    }
-    
-    func handleHorizontalPanChanged(_ pan: PanGestureRecognizer) {
-        guard let superview = self.panel.view.superview else { return }
-        
-        func dragOffset(for translation: CGPoint) -> CGFloat {
-            // TODO: Avoid the panel being dragged over the edge of the screen (if not allowed)
-            return translation.x
-        }
-
-        let translation = pan.translation(in: superview)
-        let xOffset = dragOffset(for: translation)
-        guard xOffset != 0.0 else { return }
-        
-        self.panel.animator.performWithoutAnimation { self.panel.view.transform = CGAffineTransform(translationX: xOffset, y: 0) }
-        self.panel.animator.notifyDelegateOfMove(to: self.panel.view.frame)
-        
-        // TODO: Debug
-        let midScreen = superview.bounds.midX
-        /// Calculate how large xOffset must be to reach the middle of the screen from the closer edge
-        /// - NOTE: The view is being transformed, thus the frame changes while dragging, hence the correction
-        let originalFrame = self.panel.view.frame.applying(self.panel.view.transform.inverted())
-        let threshold = min(abs(midScreen - originalFrame.maxX), abs(midScreen - originalFrame.minX))
-        debugUpdateMiddleLine(withOffset: xOffset, threshold: threshold)
-    }
-    
-    func handleHorizontalPanEnded(_ pan: PanGestureRecognizer) {
-        guard let parentView = self.panel.parent?.view else { return }
-        
-        let originalPosition = self.panel.configuration.position
-        let targetPosition = self.targetPosition(for: pan, parentView: parentView)
-        let projectedOffset = self.projectedOffset(for: pan)
-        
-        self.panel.animator.notifyDelegateOfMove(from: originalPosition, to: targetPosition)
-        self.animate(to: targetPosition, projectedOffset: projectedOffset)
-        self.cleanUpAfterHorizontalPan(pan)
-    }
-    
-    func projectedOffset(for pan: PanGestureRecognizer) -> CGFloat {
-        let velocity = pan.velocity(in: self.panel.view)
-        let translation = pan.translation(in: self.panel.view)
-        
-        return project(velocity.x, onto: translation.x)
-    }
-    
-    func targetPosition(for pan: PanGestureRecognizer, parentView: UIView) -> Panel.Configuration.Position {
-        
-        // When an edge of the panel is over the middle of the screen -> activate the move to the other side.
-        // Velocity is taken into account to calculate projection -> allow flicking the panel.
-        // FIXME: Better animation of the momevent to the target position (same as the Slide Over mode on iPad)
-        
-        let supportedPositions = self.panel.configuration.supportedPositions
-        let originalPosition = self.panel.configuration.position
-        let projectedOffset = self.projectedOffset(for: pan)
-        let delta = abs(projectedOffset)
-        let originalFrame = self.panel.view.frame.applying(self.panel.view.transform.inverted())
-        let midScreen = parentView.bounds.midX
-        /// Calculate how large xOffset must be to reach the middle of the screen from the closer edge
-        /// - NOTE: The view is being transformed, thus the frame changes while dragging, hence the correction
-        let threshold = min(abs(midScreen - originalFrame.maxX), abs(midScreen - originalFrame.minX))
-        
-        // TODO: Debug
-        self.debugShowProjectedView(projectedOffset: projectedOffset)
-        
-        // TODO: Support move to .bottom for iPad?
-        let isRTL = UIView.userInterfaceLayoutDirection(for: parentView.semanticContentAttribute) == .rightToLeft
-        let normalizedProjectedOffset = (isRTL ? -1 : 1) * projectedOffset
-        let isMovingTowardsLeadingEdge = normalizedProjectedOffset < 0
-        let isMovingTowardsTrailingEdge = normalizedProjectedOffset > 0
-        
-        guard delta > threshold else { return originalPosition }
-        
-        if isMovingTowardsLeadingEdge && supportedPositions.contains(.leadingBottom) {
-            return .leadingBottom
-        }
-        
-        if isMovingTowardsTrailingEdge && supportedPositions.contains(.trailingBottom) {
-            return .trailingBottom
-        }
-        
-        return originalPosition
-    }
-    
-    func handleHorizontalPanCancelled(_ pan: PanGestureRecognizer) {
-        
-        self.panel.animator.animateIfNeeded {
-            self.panel.view.transform = .identity
-        }
-        
-        cleanUpAfterHorizontalPan(pan)
-    }
-    
-    func cleanUpAfterHorizontalPan(_ pan: PanGestureRecognizer) {
-        self.updateResizeHandle()
-        
-        // TODO: Debug
-        middleLine?.removeFromSuperview()
-    }
-    
     func updateResizeHandle() {
-        self.panel.resizeHandle.isResizing = self.isPanning || self.isPanningHorizontally
-    }
-    
-    // MARK: - Vertical pan
-
-    @objc
-    func handlePan(_ pan: PanGestureRecognizer) {
-        switch pan.state {
-        case .began:
-            self.handlePanStarted(pan)
-        case .changed:
-            self.handlePanChanged(pan)
-        case .ended:
-            self.handlePanEnded(pan)
-        case .cancelled:
-            self.handlePanCancelled(pan)
-        default:
-            break
-        }
-    }
-    
-    func handlePanStarted(_ pan: PanGestureRecognizer) {
-        let configuration = PanelGestures.Configuration(mode: self.panel.configuration.mode,
-                                                        animateChanges: self.panel.animator.animateChanges)
-        // remember initial state
-        self.originalConfiguration = configuration
-
-        if let contentViewController = self.panel.contentViewController {
-            if self.gestureRecognizer(pan, isWithinContentAreaOf: contentViewController), let scrollView = self.verticallyScrollableView(of: contentViewController, interactingWith: pan) {
-                pan.startMode = .onVerticallyScrollableArea(competingScrollView: scrollView)
-            } else {
-                pan.startMode = .onFixedArea
-            }
-        }
-    }
-
-    func handlePanDragStart(_ pan: PanGestureRecognizer) -> Bool {
-        self.panel.animator.animateChanges = false
-        self.panel.animator.performWithoutAnimation {
-            self.panel.constraints.updateForPanStart(with: self.panel.view.frame.size)
-        }
-
-        pan.cancelsTouchesInView = true
-        self.updateResizeHandle()
-
-        let velocity = pan.velocity(in: self.panel.view)
-
-        if case .onVerticallyScrollableArea(let scrollView) = pan.startMode {
-            if velocity.y < 0.0 {
-                // if the gesture scrolls the content, cancel the resizing gesture itself
-                self.cancelVerticalPan()
-                return false
-            } else if velocity.y > 0.0 {
-                // if the gesture would shrink the panel, cancel all gestures on the competing scrollView
-                scrollView.gestureRecognizers?.forEach {
-                    $0.cancel()
-                }
-            }
-        }
-
-        return true
-    }
-
-    func handlePanChanged(_ pan: PanGestureRecognizer) {
-        guard let parentView = self.panel.parent?.view else { return }
-
-        func dragOffset(for translation: CGPoint) -> CGFloat {
-            let fudgeFactor: CGFloat = 60.0
-            let minHeight = self.height(for: .compact) + fudgeFactor
-            let maxHeight = self.panel.constraints.maxHeight - fudgeFactor
-            let currentHeight = self.currentPanelHeight
-
-            // slow down resizing if the current height exceeds certain limits
-            let isNearingEdge = (currentHeight < minHeight && translation.y > 0.0) || (currentHeight > maxHeight && translation.y < 0.0)
-            let isShrinkingOnScrollView = pan.startMode != .onFixedArea && translation.y > 0.0
-            if isNearingEdge || isShrinkingOnScrollView {
-                return translation.y / 3.0
-            } else {
-                return translation.y
-            }
-        }
-
-        let translation = pan.translation(in: self.panel.view)
-        let yOffset = dragOffset(for: translation)
-        guard yOffset != 0.0 else { return }
-
-        pan.setTranslation(.zero, in: self.panel.view)
-        if pan.didPan && pan.cancelsTouchesInView == false {
-            guard self.handlePanDragStart(pan) else { return }
-        }
-
-        self.panel.animator.performWithoutAnimation { self.panel.constraints.updateForPan(with: yOffset) }
-        self.panel.animator.notifyDelegateOfTransition(to: CGSize(width: self.panel.view.frame.width, height: self.currentPanelHeight))
-    }
-
-    func handlePanEnded(_ pan: PanGestureRecognizer) {
-        guard let originalMode = self.originalConfiguration?.mode else { return }
-
-        self.panel.constraints.updateForPanEnd()
-        guard pan.didPan || originalMode == .minimal else {
-            self.handlePanCancelled(pan)
-            return
-        }
-
-        let targetMode = self.targetMode(for: pan)
-        let initialVelocity = self.initialVelocity(for: pan, targetMode: targetMode)
-
-        self.animate(to: targetMode, initialVelocity: initialVelocity)
-        self.cleanUp(pan: pan)
-    }
-
-    func handlePanCancelled(_ pan: PanGestureRecognizer) {
-        guard let originalMode = self.originalConfiguration?.mode else { return }
-
-        let currentHeight = self.currentPanelHeight
-        self.cleanUp(pan: pan)
-
-        let size = self.panel.size(for: originalMode)
-        self.panel.animator.notifyDelegateOfTransition(from: originalMode, to: originalMode)
-        self.panel.constraints.updateForPanCancelled(with: size)
-        if currentHeight != size.height {
-            self.panel.animator.notifyDelegateOfTransition(to: size)
-        }
-    }
-
-    // swiftlint:disable cyclomatic_complexity
-    func targetMode(for pan: PanGestureRecognizer) -> Panel.Configuration.Mode {
-        let supportedModes = self.panel.configuration.supportedModes
-        guard let originalConfiguration = self.originalConfiguration else { return supportedModes.first! }
-
-        let offset: CGFloat = 100.0
-        let minVelocity: CGFloat = 20.0
-        let velocity = pan.velocity(in: self.panel.view).y
-        let heightCompact = self.height(for: .compact)
-        let heightExpanded = self.height(for: .expanded)
-        let currentHeight = self.currentPanelHeight
-
-        let isMovingUpwards = velocity < -minVelocity
-        let isMovingDownwards = velocity > minVelocity
-
-        // expand to .compact if we "tap" on .minimal
-        if isMovingUpwards == false && isMovingDownwards == false && originalConfiguration.mode == .minimal && currentHeight < heightCompact && supportedModes.contains(.compact) {
-            return .compact
-        }
-        // .minimal is only allowed when moving downwards from .compact
-        if isMovingDownwards && originalConfiguration.mode == .compact && currentHeight < heightCompact && supportedModes.contains(.minimal) {
-            return .minimal
-        }
-        // if we move up from .minimal we have a higher threshold for .expanded and prefer .compact
-        if isMovingUpwards && originalConfiguration.mode == .minimal && currentHeight < heightCompact + 40.0 && supportedModes.contains(.compact) {
-            return .compact
-        }
-        // moving upwards + current size > .expanded -> grow to .fullHeight
-        if currentHeight >= heightExpanded && isMovingUpwards && supportedModes.contains(.fullHeight) {
-            return .fullHeight
-        }
-        // moving downwards + current size < .expanded -> shrink to .collapsed
-        if currentHeight <= heightExpanded && isMovingDownwards && supportedModes.contains(.compact) {
-            return .compact
-        }
-        // moving upwards + current size < .expanded -> grow to .expanded
-        if currentHeight <= heightExpanded && isMovingUpwards {
-            if supportedModes.contains(.expanded) { return .expanded }
-            if supportedModes.contains(.fullHeight) { return .fullHeight }
-        }
-        // moving downwards + current size > .expanded -> shrink to .expanded
-        if currentHeight >= heightExpanded && isMovingDownwards {
-            if supportedModes.contains(.expanded) { return .expanded }
-            if supportedModes.contains(.compact) { return .compact }
-        }
-
-        // check distance from .expanded mode
-        let diffToExpanded = currentHeight - heightExpanded
-
-        if diffToExpanded > offset && supportedModes.contains(.fullHeight) {
-            return .fullHeight
-        } else if diffToExpanded < -offset && supportedModes.contains(.compact) {
-            return .compact
-        } else if supportedModes.contains(.expanded) {
-            return .expanded
-        } else {
-            return originalConfiguration.mode
-        }
-    }
-    // swiftlint:enable cyclomatic_complexity
-
-    func cleanUp(pan: PanGestureRecognizer) {
-        pan.cancelsTouchesInView = false
-
-        guard let originalConfiguration = self.originalConfiguration else { return }
-
-        self.updateResizeHandle()
-        self.panel.animator.animateChanges = originalConfiguration.animateChanges
-        self.originalConfiguration = nil
-    }
-
-    func height(for mode: Panel.Configuration.Mode) -> CGFloat {
-        if mode == .fullHeight {
-            return self.panel.constraints.maxHeight
-        } else {
-            return self.panel.size(for: mode).height
-        }
-    }
-    
-    func animate(to targetPosition: Panel.Configuration.Position, projectedOffset: CGFloat) {
-        // TODO: Take projected offset into account and "overshoot" the animation
-        self.panel.animator.animateIfNeeded {
-            self.panel.view.transform = .identity
-            self.panel.configuration.position = targetPosition
-        }
-    }
-    
-    func initialVelocity(for pan: PanGestureRecognizer, targetMode: Panel.Configuration.Mode) -> CGFloat {
-        let velocity = pan.velocity(in: self.panel.view).y
-        let currentHeight = self.currentPanelHeight
-        let targetHeight = self.height(for: targetMode)
-
-        let distance = targetHeight - currentHeight
-        return abs(velocity / distance)
-    }
-
-    func timing(for initialVelocity: CGFloat) -> UITimingCurveProvider {
-        let springTiming = Animation.springy.makeTiming(with: initialVelocity)
-        guard let originalConfiguration = self.originalConfiguration else { return springTiming }
-
-        if originalConfiguration.mode == .minimal || initialVelocity < 13.0 {
-            return Animation.overdamped.makeTiming(with: initialVelocity)
-        } else {
-            return springTiming
-        }
-    }
-
-    func animate(to targetMode: Panel.Configuration.Mode, initialVelocity: CGFloat) {
-        let height = self.height(for: targetMode)
-        let size = self.panel.size(for: targetMode)
-        let timing = self.timing(for: initialVelocity)
-
-        self.panel.constraints.prepareForPanEndAnimation()
-        self.panel.configuration.mode = targetMode
-        self.panel.animator.animateWithTiming(timing, animations: {
-            self.panel.constraints.updateForPanEndAnimation(to: height)
-            self.panel.animator.notifyDelegateOfTransition(to: size)
-            self.panel.fixNavigationBarLayoutMargins()
-        }, completion: {
-            self.panel.constraints.updateSizeConstraints(for: size)
-        })
-    }
-
-    // allow pan gestures to be triggered within non-safe area on top (UINavigationBar)
-    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, isWithinContentAreaOf contentViewController: UIViewController) -> Bool {
-        let offset: CGFloat = 10.0
-        let safeAreaTop: CGFloat
-        if let navigationController = contentViewController as? UINavigationController {
-            safeAreaTop = navigationController.navigationBar.frame.maxY + offset
-        } else {
-            safeAreaTop = offset
-        }
-
-        let location = gestureRecognizer.location(in: self.panel.panelView)
-        return location.y >= safeAreaTop
-    }
-
-    // allow pan gesture to be triggered when a) there's no scrollView or b) the scrollView can't be scrolled downwards
-    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, isAllowedToStartByContentOf contentViewController: UIViewController) -> Bool {
-        guard self.panel.configuration.gestureResizingMode == .includingContent else { return false }
-
-        guard let enclosingScrollView = self.verticallyScrollableView(of: contentViewController, interactingWith: gestureRecognizer) else { return true }
-        // don't allow resizing gesture if textView is currently text editing
-        if let textView = enclosingScrollView as? UITextView, textView.isFirstResponder {
-            return false
-        }
-
-        return enclosingScrollView.isScrolledToTop
-    }
-
-    func verticallyScrollableView(of contentViewController: UIViewController, interactingWith gestureRecognizer: UIGestureRecognizer) -> UIScrollView? {
-        let location = gestureRecognizer.location(in: contentViewController.view)
-        guard let hitView = contentViewController.view.hitTest(location, with: nil) else { return nil }
-
-        return hitView.findFirstSuperview(ofClass: UIScrollView.self, where: { $0.scrollsVertically })
+        self.panel.resizeHandle.isResizing = self.isPanning
     }
 }
 
@@ -605,7 +621,7 @@ private let isDebug = true
 private let isDebug = false
 #endif
 
-private extension PanelGestures {
+private extension PanelGestures.HorizontalHandler {
     
     func debugShowMiddleLine(at xPosition: CGFloat) {
         guard isDebug else { return }

--- a/Aiolos/Aiolos/Sources/PanelTransitionCoordinator.swift
+++ b/Aiolos/Aiolos/Sources/PanelTransitionCoordinator.swift
@@ -86,7 +86,7 @@ public extension PanelTransitionCoordinator {
             let supportedPositions = self.panel.configuration.supportedPositions
             let originalPosition = self.panel.configuration.position
             
-            guard self.projectedDelta > self.horizontalThreshold else { return originalPosition }
+            guard abs(self.projectedOffset) > self.horizontalThreshold else { return originalPosition }
             
             if self.isMovingTowardsLeadingEdge && supportedPositions.contains(.leadingBottom) {
                 return .leadingBottom
@@ -101,12 +101,12 @@ public extension PanelTransitionCoordinator {
         
         public var isMovingPastLeadingEdge: Bool {
             guard self.panel.configuration.position == .leadingBottom else { return false }
-            return self.destinationFrame.minX < self.leftEdgeThreshold
+            return self.originalFrame.minX + projectedOffset < self.leftEdgeThreshold
         }
         
         public var isMovingPastTrailingEdge: Bool {
             guard self.panel.configuration.position == .trailingBottom else { return false }
-            return self.destinationFrame.maxX > self.rightEdgeThreshold
+            return self.originalFrame.maxX + projectedOffset > self.rightEdgeThreshold
         }
     }
 }
@@ -115,18 +115,8 @@ public extension PanelTransitionCoordinator {
 
 private extension PanelTransitionCoordinator.HorizontalTransitionContext {
     
-    var destinationFrame: CGRect {
-        return self.panel.view.frame
-    }
-    
     var projectedOffset: CGFloat {
         return project(velocity, onto: offset)
-    }
-    
-    var projectedDelta: CGFloat {
-        let projectedOffset = self.projectedOffset
-        let delta = abs(projectedOffset)
-        return delta
     }
     
     var isMovingTowardsLeadingEdge: Bool {

--- a/Aiolos/Aiolos/Sources/PanelTransitionCoordinator.swift
+++ b/Aiolos/Aiolos/Sources/PanelTransitionCoordinator.swift
@@ -111,13 +111,13 @@ public extension PanelTransitionCoordinator {
             guard self.panel.configuration.position == .leadingBottom else { return false }
 
             if self.parentView.isRTL {
-                guard offset > 0 else { return false }
+                guard self.offset > 0 else { return false }
 
-                return self.leadingEdge + projectedOffset > self.leadingEdgeThreshold
+                return self.leadingEdge + self.projectedOffset > self.leadingEdgeThreshold
             } else {
-                guard offset < 0 else { return false }
+                guard self.offset < 0 else { return false }
 
-                return self.leadingEdge + projectedOffset < self.leadingEdgeThreshold
+                return self.leadingEdge + self.projectedOffset < self.leadingEdgeThreshold
             }
         }
         
@@ -125,13 +125,13 @@ public extension PanelTransitionCoordinator {
             guard self.panel.configuration.position == .trailingBottom else { return false }
 
             if self.parentView.isRTL {
-                guard offset < 0 else { return false }
+                guard self.offset < 0 else { return false }
 
-                return self.trailingEdge + projectedOffset < self.trailingEdgeThreshold
+                return self.trailingEdge + self.projectedOffset < self.trailingEdgeThreshold
             } else {
-                guard offset > 0 else { return false }
+                guard self.offset > 0 else { return false }
 
-                return self.trailingEdge + projectedOffset > self.trailingEdgeThreshold
+                return self.trailingEdge + self.projectedOffset > self.trailingEdgeThreshold
             }
         }
     }

--- a/Aiolos/Aiolos/Sources/PanelTransitionCoordinator.swift
+++ b/Aiolos/Aiolos/Sources/PanelTransitionCoordinator.swift
@@ -142,8 +142,14 @@ private extension PanelTransitionCoordinator.HorizontalTransitionContext {
     }
     
     var horizontalThreshold: CGFloat {
+        // An approximation of how the Slide Over mode on iPad switches the panel to the other side:
+        // - First edge of the panel is over the middle of the screen (landscape mode)
+        // - The panel is moved at least 1/2 of it width (portrait mode)
         let midScreen = self.parentView.bounds.midX
-        return min(abs(midScreen - self.originalFrame.maxX), abs(midScreen - self.originalFrame.minX))
+        let midScreenDistance = min(abs(midScreen - self.originalFrame.maxX), abs(midScreen - self.originalFrame.minX))
+        let minValue = self.originalFrame.width/2
+        let maxValue = self.parentView.bounds.width/2
+        return min(max(midScreenDistance, minValue), maxValue)
     }
     
     var rightEdgeThreshold: CGFloat {

--- a/Aiolos/Aiolos/Sources/PanelTransitionCoordinator.swift
+++ b/Aiolos/Aiolos/Sources/PanelTransitionCoordinator.swift
@@ -70,10 +70,10 @@ public extension PanelTransitionCoordinator {
     final class HorizontalTransitionContext {
         
         private unowned let panel: Panel
-        private unowned let parentView: UIView
+        unowned let parentView: UIView
         private let originalFrame: CGRect
-        private let offset: CGFloat
-        private let velocity: CGFloat
+        let offset: CGFloat
+        let velocity: CGFloat
         
         // MARK: Lifecycle
         

--- a/Aiolos/Aiolos/Sources/PanelTransitionCoordinator.swift
+++ b/Aiolos/Aiolos/Sources/PanelTransitionCoordinator.swift
@@ -13,24 +13,40 @@ import UIKit
 /// This coordinator can be used to animate things alongside the movement of the Panel
 public final class PanelTransitionCoordinator {
 
+    public enum Direction {
+        case horizontal(context: HorizontalTransitionContext)
+        case vertical
+    }
+    
     private unowned let animator: PanelAnimator
 
     // MARK: - Properties
 
+    public let direction: Direction
     public var isAnimated: Bool { return self.animator.animateChanges }
-    public let context: HorizontalTransitionContext?
     
     // MARK: - Lifecycle
 
-    init(animator: PanelAnimator, context: HorizontalTransitionContext? = nil) {
+    init(animator: PanelAnimator, direction: Direction) {
         self.animator = animator
-        self.context = context
+        self.direction = direction
     }
 
     // MARK: - PanelTransitionCoordinator
 
     public func animateAlongsideTransition(_ animations: @escaping () -> Void, completion: ((UIViewAnimatingPosition) -> Void)? = nil) {
         self.animator.transitionCoordinatorQueuedAnimations.append(Animation(animations: animations, completion: completion))
+    }
+}
+
+extension PanelTransitionCoordinator.Direction {
+    public var context: PanelTransitionCoordinator.HorizontalTransitionContext? {
+        switch self {
+        case .horizontal(let context):
+            return context
+        case .vertical:
+            return nil
+        }
     }
 }
 

--- a/Aiolos/Aiolos/Sources/PanelTransitionCoordinator.swift
+++ b/Aiolos/Aiolos/Sources/PanelTransitionCoordinator.swift
@@ -70,8 +70,11 @@ public extension PanelTransitionCoordinator {
     final class HorizontalTransitionContext {
         
         private unowned let panel: Panel
-        unowned let parentView: UIView
         private let originalFrame: CGRect
+        
+        // MARK: Properties
+        
+        unowned let parentView: UIView
         let offset: CGFloat
         let velocity: CGFloat
         

--- a/Aiolos/Aiolos/Sources/PanelTransitionCoordinator.swift
+++ b/Aiolos/Aiolos/Sources/PanelTransitionCoordinator.swift
@@ -117,11 +117,11 @@ public extension PanelTransitionCoordinator {
             guard self.panel.configuration.position == .leadingBottom else { return false }
 
             if self.parentView.isRTL {
-                guard self.offset > 0 else { return false }
+                guard self.offset > 0.0 else { return false }
 
                 return self.leadingEdge + self.projectedOffset > self.leadingEdgeThreshold
             } else {
-                guard self.offset < 0 else { return false }
+                guard self.offset < 0.0 else { return false }
 
                 return self.leadingEdge + self.projectedOffset < self.leadingEdgeThreshold
             }
@@ -131,11 +131,11 @@ public extension PanelTransitionCoordinator {
             guard self.panel.configuration.position == .trailingBottom else { return false }
 
             if self.parentView.isRTL {
-                guard self.offset < 0 else { return false }
+                guard self.offset < 0.0 else { return false }
 
                 return self.trailingEdge + self.projectedOffset < self.trailingEdgeThreshold
             } else {
-                guard self.offset > 0 else { return false }
+                guard self.offset > 0.0 else { return false }
 
                 return self.trailingEdge + self.projectedOffset > self.trailingEdgeThreshold
             }
@@ -158,17 +158,17 @@ private extension PanelTransitionCoordinator.HorizontalTransitionContext {
     }
     
     var isMovingTowardsLeadingEdge: Bool {
-        let normalizedOffset = (self.parentView.isRTL ? -1 : 1) * self.offset
-        let normalizedVelocity = (self.parentView.isRTL ? -1 : 1) * self.velocity
+        let normalizedOffset = (self.parentView.isRTL ? -1.0 : 1.0) * self.offset
+        let normalizedVelocity = (self.parentView.isRTL ? -1.0 : 1.0) * self.velocity
         
-        return normalizedOffset < 0 && normalizedVelocity < 0
+        return normalizedOffset < 0.0 && normalizedVelocity < 0.0
     }
     
     var isMovingTowardsTrailingEdge: Bool {
-        let normalizedOffset = (self.parentView.isRTL ? -1 : 1) * self.offset
-        let normalizedVelocity = (self.parentView.isRTL ? -1 : 1) * self.velocity
+        let normalizedOffset = (self.parentView.isRTL ? -1.0 : 1.0) * self.offset
+        let normalizedVelocity = (self.parentView.isRTL ? -1.0 : 1.0) * self.velocity
         
-        return normalizedOffset > 0 && normalizedVelocity > 0
+        return normalizedOffset > 0.0 && normalizedVelocity > 0.0
     }
     
     var horizontalThreshold: CGFloat {
@@ -185,13 +185,13 @@ private extension PanelTransitionCoordinator.HorizontalTransitionContext {
     
     var trailingEdgeThreshold: CGFloat {
         let trailingEdge = (self.parentView.isRTL ? self.parentView.bounds.minX : self.parentView.bounds.maxX)
-        let directionMultiplier: CGFloat = self.parentView.isRTL ? -1 : 1
+        let directionMultiplier: CGFloat = self.parentView.isRTL ? -1.0 : 1.0
         return trailingEdge + directionMultiplier * self.originalFrame.width
     }
     
     var leadingEdgeThreshold: CGFloat {
         let leadingEdge = (self.parentView.isRTL ? self.parentView.bounds.maxX : self.parentView.bounds.minX)
-        let directionMultiplier: CGFloat = self.parentView.isRTL ? -1 : 1
+        let directionMultiplier: CGFloat = self.parentView.isRTL ? -1.0 : 1.0
         return leadingEdge - directionMultiplier * self.originalFrame.width
     }
     
@@ -201,12 +201,5 @@ private extension PanelTransitionCoordinator.HorizontalTransitionContext {
     
     var leadingEdge: CGFloat {
         return self.parentView.isRTL ? self.originalFrame.maxX : self.originalFrame.minX
-    }
-}
-
-private extension UIView {
-
-    var isRTL: Bool {
-        return self.effectiveUserInterfaceLayoutDirection == .rightToLeft
     }
 }

--- a/Aiolos/Aiolos/Sources/PanelTransitionCoordinator.swift
+++ b/Aiolos/Aiolos/Sources/PanelTransitionCoordinator.swift
@@ -82,7 +82,7 @@ public extension PanelTransitionCoordinator {
         
         // MARK: - HorizontalTransitionContext
         
-        public func targetPosition(in view: UIView) -> Panel.Configuration.Position {
+        public var targetPosition: Panel.Configuration.Position {
             let supportedPositions = self.panel.configuration.supportedPositions
             let originalPosition = self.panel.configuration.position
             

--- a/Aiolos/Aiolos/Sources/PanelTransitionCoordinator.swift
+++ b/Aiolos/Aiolos/Sources/PanelTransitionCoordinator.swift
@@ -180,13 +180,13 @@ private extension PanelTransitionCoordinator.HorizontalTransitionContext {
     var trailingEdgeThreshold: CGFloat {
         let trailingEdge = (self.parentView.isRTL ? self.parentView.bounds.minX : self.parentView.bounds.maxX)
         let directionMultiplier: CGFloat = self.parentView.isRTL ? -1 : 1
-        return trailingEdge + (directionMultiplier * self.originalFrame.width / 3.0)
+        return trailingEdge + directionMultiplier * self.originalFrame.width
     }
     
     var leadingEdgeThreshold: CGFloat {
         let leadingEdge = (self.parentView.isRTL ? self.parentView.bounds.maxX : self.parentView.bounds.minX)
         let directionMultiplier: CGFloat = self.parentView.isRTL ? -1 : 1
-        return leadingEdge - (directionMultiplier * self.originalFrame.width / 3.0)
+        return leadingEdge - directionMultiplier * self.originalFrame.width
     }
     
     var trailingEdge: CGFloat {

--- a/Aiolos/Aiolos/Sources/PanelTransitionCoordinator.swift
+++ b/Aiolos/Aiolos/Sources/PanelTransitionCoordinator.swift
@@ -152,15 +152,17 @@ private extension PanelTransitionCoordinator.HorizontalTransitionContext {
     }
     
     var isMovingTowardsLeadingEdge: Bool {
-        let normalizedProjectedOffset = (self.parentView.isRTL ? -1 : 1) * self.projectedOffset
+        let normalizedOffset = (self.parentView.isRTL ? -1 : 1) * self.offset
+        let normalizedVelocity = (self.parentView.isRTL ? -1 : 1) * self.velocity
         
-        return normalizedProjectedOffset < 0
+        return normalizedOffset < 0 && normalizedVelocity < 0
     }
     
     var isMovingTowardsTrailingEdge: Bool {
-        let normalizedProjectedOffset = (self.parentView.isRTL ? -1 : 1) * self.projectedOffset
+        let normalizedOffset = (self.parentView.isRTL ? -1 : 1) * self.offset
+        let normalizedVelocity = (self.parentView.isRTL ? -1 : 1) * self.velocity
         
-        return normalizedProjectedOffset > 0
+        return normalizedOffset > 0 && normalizedVelocity > 0
     }
     
     var horizontalThreshold: CGFloat {

--- a/Aiolos/Aiolos/Sources/PanelTransitionCoordinator.swift
+++ b/Aiolos/Aiolos/Sources/PanelTransitionCoordinator.swift
@@ -80,50 +80,18 @@ public extension PanelTransitionCoordinator {
         
         // MARK: - HorizontalTransitionContext
         
-        public var projectedOffset: CGFloat {
-            return project(velocity, onto: offset)
-        }
-        
-        public var projectedDelta: CGFloat {
-            let projectedOffset = self.projectedOffset
-            let delta = abs(projectedOffset)
-            return delta
-        }
-        
-        public func horizontalThreshold(in view: UIView) -> CGFloat {
-            let midScreen = view.bounds.midX
-            return min(abs(midScreen - self.originalFrame.maxX), abs(midScreen - self.originalFrame.minX))
-        }
-        
-        public func rightEdgeThreshold(in view: UIView) -> CGFloat {
-            return view.bounds.maxX + self.originalFrame.width/3
-        }
-        
-        public func leftEdgeThreshold(in view: UIView) -> CGFloat {
-            return view.bounds.minX - self.originalFrame.width/3
-        }
-        
-        public func isMovingTowardsLeadingEdge(in view: UIView) -> Bool {
-            let normalizedProjectedOffset = (view.isRTL ? -1 : 1) * self.projectedOffset
-            
-            return normalizedProjectedOffset < 0
-        }
-        
-        public func isMovingTowardsTrailingEdge(in view: UIView) -> Bool {
-            let normalizedProjectedOffset = (view.isRTL ? -1 : 1) * self.projectedOffset
-            
-            return normalizedProjectedOffset > 0
-        }
-        
         public func targetPosition(in view: UIView) -> Panel.Configuration.Position {
-            let supportedPositions = panel.configuration.supportedPositions
-            let originalPosition = panel.configuration.position
+            let supportedPositions = self.panel.configuration.supportedPositions
+            let originalPosition = self.panel.configuration.position
+            let threshold = self.horizontalThreshold(in: view)
             
-            if isMovingTowardsLeadingEdge(in: view) && supportedPositions.contains(.leadingBottom) {
+            guard self.projectedDelta > threshold else { return originalPosition }
+            
+            if self.isMovingTowardsLeadingEdge(in: view) && supportedPositions.contains(.leadingBottom) {
                 return .leadingBottom
             }
             
-            if isMovingTowardsTrailingEdge(in: view) && supportedPositions.contains(.trailingBottom) {
+            if self.isMovingTowardsTrailingEdge(in: view) && supportedPositions.contains(.trailingBottom) {
                 return .trailingBottom
             }
             
@@ -132,12 +100,12 @@ public extension PanelTransitionCoordinator {
         
         public func isMovingPastLeadingEdge(in view: UIView) -> Bool {
             guard self.panel.configuration.position == .leadingBottom else { return false }
-            return self.destinationFrame.minX < leftEdgeThreshold(in: view)
+            return self.destinationFrame.minX < self.leftEdgeThreshold(in: view)
         }
         
         public func isMovingPastTrailingEdge(in view: UIView) -> Bool {
             guard self.panel.configuration.position == .trailingBottom else { return false }
-            return self.destinationFrame.maxX > rightEdgeThreshold(in: view)
+            return self.destinationFrame.maxX > self.rightEdgeThreshold(in: view)
         }
     }
 }
@@ -148,6 +116,41 @@ private extension PanelTransitionCoordinator.HorizontalTransitionContext {
     
     var destinationFrame: CGRect {
         return self.panel.view.frame
+    }
+    
+    var projectedOffset: CGFloat {
+        return project(velocity, onto: offset)
+    }
+    
+    var projectedDelta: CGFloat {
+        let projectedOffset = self.projectedOffset
+        let delta = abs(projectedOffset)
+        return delta
+    }
+    
+    func isMovingTowardsLeadingEdge(in view: UIView) -> Bool {
+        let normalizedProjectedOffset = (view.isRTL ? -1 : 1) * self.projectedOffset
+        
+        return normalizedProjectedOffset < 0
+    }
+    
+    func isMovingTowardsTrailingEdge(in view: UIView) -> Bool {
+        let normalizedProjectedOffset = (view.isRTL ? -1 : 1) * self.projectedOffset
+        
+        return normalizedProjectedOffset > 0
+    }
+    
+    func horizontalThreshold(in view: UIView) -> CGFloat {
+        let midScreen = view.bounds.midX
+        return min(abs(midScreen - self.originalFrame.maxX), abs(midScreen - self.originalFrame.minX))
+    }
+    
+    func rightEdgeThreshold(in view: UIView) -> CGFloat {
+        return view.bounds.maxX + self.originalFrame.width/3
+    }
+    
+    func leftEdgeThreshold(in view: UIView) -> CGFloat {
+        return view.bounds.minX - self.originalFrame.width/3
     }
 }
 

--- a/Aiolos/Aiolos/Sources/PanelTransitionCoordinator.swift
+++ b/Aiolos/Aiolos/Sources/PanelTransitionCoordinator.swift
@@ -101,12 +101,24 @@ public extension PanelTransitionCoordinator {
         
         public var isMovingPastLeadingEdge: Bool {
             guard self.panel.configuration.position == .leadingBottom else { return false }
-            return self.originalFrame.minX + projectedOffset < self.leftEdgeThreshold
+            if self.parentView.isRTL {
+                guard offset > 0 else { return false }
+                return self.leadingEdge + projectedOffset > self.leadingEdgeThreshold
+            } else {
+                guard offset < 0 else { return false }
+                return self.leadingEdge + projectedOffset < self.leadingEdgeThreshold
+            }
         }
         
         public var isMovingPastTrailingEdge: Bool {
             guard self.panel.configuration.position == .trailingBottom else { return false }
-            return self.originalFrame.maxX + projectedOffset > self.rightEdgeThreshold
+            if self.parentView.isRTL {
+                guard offset < 0 else { return false }
+                return self.trailingEdge + projectedOffset < self.trailingEdgeThreshold
+            } else {
+                guard offset > 0 else { return false }
+                return self.trailingEdge + projectedOffset > self.trailingEdgeThreshold
+            }
         }
     }
 }
@@ -142,12 +154,24 @@ private extension PanelTransitionCoordinator.HorizontalTransitionContext {
         return min(max(midScreenDistance, minValue), maxValue)
     }
     
-    var rightEdgeThreshold: CGFloat {
-        return self.parentView.bounds.maxX + self.originalFrame.width/3
+    var trailingEdgeThreshold: CGFloat {
+        let trailingEdge = (self.parentView.isRTL ? self.parentView.bounds.minX : self.parentView.bounds.maxX)
+        let directionMultiplier: CGFloat = self.parentView.isRTL ? -1 : 1
+        return trailingEdge + (directionMultiplier * self.originalFrame.width/3)
     }
     
-    var leftEdgeThreshold: CGFloat {
-        return self.parentView.bounds.minX - self.originalFrame.width/3
+    var leadingEdgeThreshold: CGFloat {
+        let leadingEdge = (self.parentView.isRTL ? self.parentView.bounds.maxX : self.parentView.bounds.minX)
+        let directionMultiplier: CGFloat = self.parentView.isRTL ? -1 : 1
+        return leadingEdge - (directionMultiplier * self.originalFrame.width/3)
+    }
+    
+    var trailingEdge: CGFloat {
+        return self.parentView.isRTL ? self.originalFrame.minX : self.originalFrame.maxX
+    }
+    
+    var leadingEdge: CGFloat {
+        return self.parentView.isRTL ? self.originalFrame.maxX : self.originalFrame.minX
     }
 }
 

--- a/Aiolos/Aiolos/Sources/PanelTransitionCoordinator.swift
+++ b/Aiolos/Aiolos/Sources/PanelTransitionCoordinator.swift
@@ -90,16 +90,14 @@ public extension PanelTransitionCoordinator {
         
         public func isMovingTowardsLeadingEdge(in view: UIView) -> Bool {
             let projectedOffset = self.projectedOffset(in: view)
-            let isRTL = UIView.userInterfaceLayoutDirection(for: view.semanticContentAttribute) == .rightToLeft
-            let normalizedProjectedOffset = (isRTL ? -1 : 1) * projectedOffset
+            let normalizedProjectedOffset = (view.isRTL ? -1 : 1) * projectedOffset
             
             return normalizedProjectedOffset < 0
         }
         
         public func isMovingTowardsTrailingEdge(in view: UIView) -> Bool {
             let projectedOffset = self.projectedOffset(in: view)
-            let isRTL = UIView.userInterfaceLayoutDirection(for: view.semanticContentAttribute) == .rightToLeft
-            let normalizedProjectedOffset = (isRTL ? -1 : 1) * projectedOffset
+            let normalizedProjectedOffset = (view.isRTL ? -1 : 1) * projectedOffset
             
             return normalizedProjectedOffset > 0
         }
@@ -137,6 +135,12 @@ private extension PanelTransitionCoordinator.HorizontalTransitionContext {
     
     var destinationFrame: CGRect {
         return self.panel.view.frame
+    }
+}
+
+private extension UIView {
+    var isRTL: Bool {
+        return self.effectiveUserInterfaceLayoutDirection == .rightToLeft
     }
 }
 

--- a/Aiolos/Aiolos/Sources/PanelTransitionCoordinator.swift
+++ b/Aiolos/Aiolos/Sources/PanelTransitionCoordinator.swift
@@ -65,27 +65,33 @@ public extension PanelTransitionCoordinator {
     final class HorizontalTransitionContext {
         
         private unowned let panel: Panel
-        private let pan: PanGestureRecognizer
         private let originalFrame: CGRect
+        private let offset: CGFloat
+        private let velocity: CGFloat
         
         // MARK: - Lifecycle
         
-        init(panel: Panel, pan: PanGestureRecognizer, originalFrame: CGRect) {
+        init(panel: Panel, originalFrame: CGRect, offset: CGFloat, velocity: CGFloat) {
             self.panel = panel
-            self.pan = pan
             self.originalFrame = originalFrame
+            self.offset = offset
+            self.velocity = velocity
         }
         
         // MARK: - HorizontalTransitionContext
         
-        public func projectedDelta(in view: UIView) -> CGFloat {
-            let projectedOffset = self.projectedOffset(in: view)
+        public var projectedOffset: CGFloat {
+            return project(velocity, onto: offset)
+        }
+        
+        public var projectedDelta: CGFloat {
+            let projectedOffset = self.projectedOffset
             let delta = abs(projectedOffset)
             return delta
         }
         
         public func horizontalThreshold(in view: UIView) -> CGFloat {
-            let midScreen = view.bounds.minX
+            let midScreen = view.bounds.midX
             return min(abs(midScreen - self.originalFrame.maxX), abs(midScreen - self.originalFrame.minX))
         }
         
@@ -97,23 +103,14 @@ public extension PanelTransitionCoordinator {
             return view.bounds.minX - self.originalFrame.width/3
         }
         
-        public func projectedOffset(in view: UIView) -> CGFloat {
-            let velocity = self.pan.velocity(in: view)
-            let translation = self.pan.translation(in: view)
-            
-            return project(velocity.x, onto: translation.x)
-        }
-        
         public func isMovingTowardsLeadingEdge(in view: UIView) -> Bool {
-            let projectedOffset = self.projectedOffset(in: view)
-            let normalizedProjectedOffset = (view.isRTL ? -1 : 1) * projectedOffset
+            let normalizedProjectedOffset = (view.isRTL ? -1 : 1) * self.projectedOffset
             
             return normalizedProjectedOffset < 0
         }
         
         public func isMovingTowardsTrailingEdge(in view: UIView) -> Bool {
-            let projectedOffset = self.projectedOffset(in: view)
-            let normalizedProjectedOffset = (view.isRTL ? -1 : 1) * projectedOffset
+            let normalizedProjectedOffset = (view.isRTL ? -1 : 1) * self.projectedOffset
             
             return normalizedProjectedOffset > 0
         }

--- a/Aiolos/Aiolos/Sources/PanelTransitionCoordinator.swift
+++ b/Aiolos/Aiolos/Sources/PanelTransitionCoordinator.swift
@@ -18,6 +18,12 @@ public final class PanelTransitionCoordinator {
         case vertical
     }
     
+    public enum Instruction {
+        case updatePosition(_ newPosition: Panel.Configuration.Position)
+        case hide
+        case none
+    }
+    
     private unowned let animator: PanelAnimator
 
     // MARK: - Properties

--- a/Aiolos/Aiolos/Sources/PanelTransitionCoordinator.swift
+++ b/Aiolos/Aiolos/Sources/PanelTransitionCoordinator.swift
@@ -145,7 +145,7 @@ private extension PanelTransitionCoordinator.HorizontalTransitionContext {
             return position + factor * velocity
         }
 
-        return project(velocity, onto: offset)
+        return project(self.velocity, onto: self.offset)
     }
     
     var isMovingTowardsLeadingEdge: Bool {

--- a/Aiolos/Aiolos/Sources/PanelTransitionCoordinator.swift
+++ b/Aiolos/Aiolos/Sources/PanelTransitionCoordinator.swift
@@ -65,14 +65,16 @@ public extension PanelTransitionCoordinator {
     final class HorizontalTransitionContext {
         
         private unowned let panel: Panel
+        private unowned let parentView: UIView
         private let originalFrame: CGRect
         private let offset: CGFloat
         private let velocity: CGFloat
         
         // MARK: - Lifecycle
         
-        init(panel: Panel, originalFrame: CGRect, offset: CGFloat, velocity: CGFloat) {
+        init(panel: Panel, parentView: UIView, originalFrame: CGRect, offset: CGFloat, velocity: CGFloat) {
             self.panel = panel
+            self.parentView = parentView
             self.originalFrame = originalFrame
             self.offset = offset
             self.velocity = velocity
@@ -83,29 +85,28 @@ public extension PanelTransitionCoordinator {
         public func targetPosition(in view: UIView) -> Panel.Configuration.Position {
             let supportedPositions = self.panel.configuration.supportedPositions
             let originalPosition = self.panel.configuration.position
-            let threshold = self.horizontalThreshold(in: view)
             
-            guard self.projectedDelta > threshold else { return originalPosition }
+            guard self.projectedDelta > self.horizontalThreshold else { return originalPosition }
             
-            if self.isMovingTowardsLeadingEdge(in: view) && supportedPositions.contains(.leadingBottom) {
+            if self.isMovingTowardsLeadingEdge && supportedPositions.contains(.leadingBottom) {
                 return .leadingBottom
             }
             
-            if self.isMovingTowardsTrailingEdge(in: view) && supportedPositions.contains(.trailingBottom) {
+            if self.isMovingTowardsTrailingEdge && supportedPositions.contains(.trailingBottom) {
                 return .trailingBottom
             }
             
             return originalPosition
         }
         
-        public func isMovingPastLeadingEdge(in view: UIView) -> Bool {
+        public var isMovingPastLeadingEdge: Bool {
             guard self.panel.configuration.position == .leadingBottom else { return false }
-            return self.destinationFrame.minX < self.leftEdgeThreshold(in: view)
+            return self.destinationFrame.minX < self.leftEdgeThreshold
         }
         
-        public func isMovingPastTrailingEdge(in view: UIView) -> Bool {
+        public var isMovingPastTrailingEdge: Bool {
             guard self.panel.configuration.position == .trailingBottom else { return false }
-            return self.destinationFrame.maxX > self.rightEdgeThreshold(in: view)
+            return self.destinationFrame.maxX > self.rightEdgeThreshold
         }
     }
 }
@@ -128,29 +129,29 @@ private extension PanelTransitionCoordinator.HorizontalTransitionContext {
         return delta
     }
     
-    func isMovingTowardsLeadingEdge(in view: UIView) -> Bool {
-        let normalizedProjectedOffset = (view.isRTL ? -1 : 1) * self.projectedOffset
+    var isMovingTowardsLeadingEdge: Bool {
+        let normalizedProjectedOffset = (self.parentView.isRTL ? -1 : 1) * self.projectedOffset
         
         return normalizedProjectedOffset < 0
     }
     
-    func isMovingTowardsTrailingEdge(in view: UIView) -> Bool {
-        let normalizedProjectedOffset = (view.isRTL ? -1 : 1) * self.projectedOffset
+    var isMovingTowardsTrailingEdge: Bool {
+        let normalizedProjectedOffset = (self.parentView.isRTL ? -1 : 1) * self.projectedOffset
         
         return normalizedProjectedOffset > 0
     }
     
-    func horizontalThreshold(in view: UIView) -> CGFloat {
-        let midScreen = view.bounds.midX
+    var horizontalThreshold: CGFloat {
+        let midScreen = self.parentView.bounds.midX
         return min(abs(midScreen - self.originalFrame.maxX), abs(midScreen - self.originalFrame.minX))
     }
     
-    func rightEdgeThreshold(in view: UIView) -> CGFloat {
-        return view.bounds.maxX + self.originalFrame.width/3
+    var rightEdgeThreshold: CGFloat {
+        return self.parentView.bounds.maxX + self.originalFrame.width/3
     }
     
-    func leftEdgeThreshold(in view: UIView) -> CGFloat {
-        return view.bounds.minX - self.originalFrame.width/3
+    var leftEdgeThreshold: CGFloat {
+        return self.parentView.bounds.minX - self.originalFrame.width/3
     }
 }
 

--- a/Aiolos/Aiolos/Sources/UIView+RTL.swift
+++ b/Aiolos/Aiolos/Sources/UIView+RTL.swift
@@ -1,0 +1,17 @@
+//
+//  UIView+RTL.swift
+//  Aiolos
+//
+//  Created by Matthias Tretter on 25.01.19.
+//  Copyright © 2019 Matthias Tretter. All rights reserved.
+//
+
+import Foundation
+
+
+extension UIView {
+
+    var isRTL: Bool {
+        return self.effectiveUserInterfaceLayoutDirection == .rightToLeft
+    }
+}

--- a/Aiolos/Demo/ViewController.swift
+++ b/Aiolos/Demo/ViewController.swift
@@ -96,6 +96,12 @@ extension ViewController: PanelSizeDelegate {
     }
 }
 
+// MARK: - PanelPositionDelegate
+
+extension ViewController: PanelPositionDelegate {
+    
+}
+
 // MARK: - PanelAnimationDelegate
 
 extension ViewController: PanelAnimationDelegate {
@@ -114,20 +120,23 @@ extension ViewController: PanelAnimationDelegate {
             print("Completed panel transition to \(newMode)")
         })
     }
-}
-
-// MARK: - PanelPositionDelegate
-
-extension ViewController: PanelPositionDelegate {
     
     func panel(_ panel: Panel, willMoveTo frame: CGRect) {
         print("Panel will move to frame \(frame)")
     }
     
-    func panel(_ panel: Panel, willMoveFrom oldPosition: Panel.Configuration.Position, to newPosition: Panel.Configuration.Position) {
+    func panel(_ panel: Panel, willMoveFrom oldPosition: Panel.Configuration.Position, to newPosition: Panel.Configuration.Position, with coordinator: PanelTransitionCoordinator) {
         print("Panel will transition from \(oldPosition) to \(newPosition)")
+        
+        // we can animate things along the way
+        coordinator.animateAlongsideTransition({
+            print("Animating alongside of panel movement")
+        }, completion: { animationPosition in
+            print("Completed panel movement to \(newPosition)")
+        })
     }
 }
+
 
 // MARK: - Private
 

--- a/Aiolos/Demo/ViewController.swift
+++ b/Aiolos/Demo/ViewController.swift
@@ -138,9 +138,11 @@ private extension ViewController {
         panelController.configuration.appearance.separatorColor = .white
 
         if self.traitCollection.userInterfaceIdiom == .pad {
+            panelController.configuration.supportedPositions = [.leadingBottom, .trailingBottom]
             panelController.configuration.appearance.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner, .layerMinXMaxYCorner, .layerMaxXMaxYCorner]
         } else {
             panelController.configuration.supportedModes = [.minimal, .compact, .expanded, .fullHeight]
+            panelController.configuration.supportedPositions = [.bottom]
             panelController.configuration.appearance.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
         }
 

--- a/Aiolos/Demo/ViewController.swift
+++ b/Aiolos/Demo/ViewController.swift
@@ -124,7 +124,7 @@ extension ViewController: PanelAnimationDelegate {
 
         print("Panel did move to frame \(destination)")
         
-        let panelShouldHide = context.isMovingPastLeadingEdge(in: self.view) || context.isMovingPastTrailingEdge(in: self.view)
+        let panelShouldHide = context.isMovingPastLeadingEdge || context.isMovingPastTrailingEdge
         if panelShouldHide {
             coordinator.animateAlongsideTransition({
                 panel.removeFromParent(transition: .slide(direction: .horizontal))

--- a/Aiolos/Demo/ViewController.swift
+++ b/Aiolos/Demo/ViewController.swift
@@ -123,6 +123,16 @@ extension ViewController: PanelAnimationDelegate {
     
     func panel(_ panel: Panel, willMoveTo frame: CGRect) {
         print("Panel will move to frame \(frame)")
+        
+        // FIXME: Removing the panel when the gesture hasn't yet finished does not make nice UX
+        let rightEdgeThreshold = self.view.bounds.maxX + frame.width/3
+        let leftEdgeThreshold = self.view.bounds.minX - frame.width/3
+        
+        if frame.maxX > rightEdgeThreshold {
+            panel.removeFromParent(transition: .slide(direction: .horizontal))
+        } else if frame.minX < leftEdgeThreshold {
+            panel.removeFromParent(transition: .slide(direction: .horizontal))
+        }
     }
     
     func panel(_ panel: Panel, willMoveFrom oldPosition: Panel.Configuration.Position, to newPosition: Panel.Configuration.Position, with coordinator: PanelTransitionCoordinator) {
@@ -194,9 +204,9 @@ private extension ViewController {
     @objc
     func handleToggleVisibilityPress() {
         if self.panelController.isVisible {
-            self.panelController.removeFromParent(transition: .slide(direction: .vertical))
+            self.panelController.removeFromParent(transition: .slide(direction: .horizontal))
         } else {
-            self.panelController.add(to: self, transition: .slide(direction: .vertical))
+            self.panelController.add(to: self, transition: .slide(direction: .horizontal))
         }
     }
 

--- a/Aiolos/Demo/ViewController.swift
+++ b/Aiolos/Demo/ViewController.swift
@@ -141,17 +141,6 @@ extension ViewController: PanelAnimationDelegate {
             }
         }
     }
-    
-    func panel(_ panel: Panel, willMoveFrom oldPosition: Panel.Configuration.Position, to newPosition: Panel.Configuration.Position, with coordinator: PanelTransitionCoordinator) {
-        print("Panel will transition from \(oldPosition) to \(newPosition)")
-        
-        // we can animate things along the way
-        coordinator.animateAlongsideTransition({
-            print("Animating alongside of panel movement")
-        }, completion: { animationPosition in
-            print("Completed panel movement to \(newPosition)")
-        })
-    }
 }
 
 

--- a/Aiolos/Demo/ViewController.swift
+++ b/Aiolos/Demo/ViewController.swift
@@ -119,10 +119,6 @@ extension ViewController: PanelAnimationDelegate {
         return true
     }
     
-    func panel(_ panel: Panel, willMoveTo frame: CGRect) {
-        print("Panel will move to frame \(frame)")
-    }
-    
     func panel(_ panel: Panel, didMoveFrom origin: CGRect, to destination: CGRect, with coordinator: PanelTransitionCoordinator) {
         guard let context = coordinator.context else { return }
 

--- a/Aiolos/Demo/ViewController.swift
+++ b/Aiolos/Demo/ViewController.swift
@@ -119,25 +119,16 @@ extension ViewController: PanelAnimationDelegate {
         return true
     }
     
-    func panel(_ panel: Panel, didMoveFrom oldFrame: CGRect, to newFrame: CGRect, with coordinator: PanelTransitionCoordinator) {
-        guard let context = coordinator.direction.context else { return }
+    func panel(_ panel: Panel, didMoveFrom oldFrame: CGRect, to newFrame: CGRect, with coordinator: PanelTransitionCoordinator) -> PanelTransitionCoordinator.Instruction {
+        guard let context = coordinator.direction.context else { return .none }
 
         print("Panel did move to frame \(newFrame)")
         
         let panelShouldHide = context.isMovingPastLeadingEdge || context.isMovingPastTrailingEdge
         if panelShouldHide {
-            coordinator.animateAlongsideTransition({
-                panel.removeFromParent(transition: .slide(direction: .horizontal))
-            }, completion: { animationPosition in
-                print("Completed panel transition to hidden")
-            })
+            return .hide
         } else {
-            coordinator.animateAlongsideTransition({
-                print("Animating alongside of panel transition to target position: \(context.targetPosition)")
-                panel.configuration.position = context.targetPosition
-            }) { animationPosition in
-                print("Completed panel transition to hidden")
-            }
+            return .updatePosition(context.targetPosition)
         }
     }
 }

--- a/Aiolos/Demo/ViewController.swift
+++ b/Aiolos/Demo/ViewController.swift
@@ -96,12 +96,6 @@ extension ViewController: PanelSizeDelegate {
     }
 }
 
-// MARK: - PanelPositionDelegate
-
-extension ViewController: PanelPositionDelegate {
-    
-}
-
 // MARK: - PanelAnimationDelegate
 
 extension ViewController: PanelAnimationDelegate {
@@ -164,7 +158,6 @@ private extension ViewController {
 
         panelController.sizeDelegate = self
         panelController.animationDelegate = self
-        panelController.positionDelegate = self
         panelController.contentViewController = contentNavigationController
         panelController.configuration.position = self.panelPosition(for: self.traitCollection)
         panelController.configuration.margins = self.panelMargins(for: self.traitCollection)

--- a/Aiolos/Demo/ViewController.swift
+++ b/Aiolos/Demo/ViewController.swift
@@ -117,15 +117,28 @@ extension ViewController: PanelAnimationDelegate {
     
     func panel(_ panel: Panel, willMoveTo frame: CGRect) {
         print("Panel will move to frame \(frame)")
+    }
+    
+    func panel(_ panel: Panel, didMoveFrom origin: CGRect, to destination: CGRect, with coordinator: PanelTransitionCoordinator) {
+        guard let context = coordinator.context else { return }
+
+        print("Panel did move to frame \(destination)")
         
-        // FIXME: Removing the panel when the gesture hasn't yet finished does not make nice UX
-        let rightEdgeThreshold = self.view.bounds.maxX + frame.width/3
-        let leftEdgeThreshold = self.view.bounds.minX - frame.width/3
-        
-        if frame.maxX > rightEdgeThreshold {
-            panel.removeFromParent(transition: .slide(direction: .horizontal))
-        } else if frame.minX < leftEdgeThreshold {
-            panel.removeFromParent(transition: .slide(direction: .horizontal))
+        let panelShouldHide = context.isMovingPastLeadingEdge(in: self.view) || context.isMovingPastTrailingEdge(in: self.view)
+        if panelShouldHide {
+            coordinator.animateAlongsideTransition({
+                panel.removeFromParent(transition: .slide(direction: .horizontal))
+            }, completion: { animationPosition in
+                print("Completed panel transition to hidden")
+            })
+        } else {
+            let targetPosition = context.targetPosition(in: self.view)
+            coordinator.animateAlongsideTransition({
+                print("Animating alongside of panel transition to target position: \(targetPosition)")
+                panel.configuration.position = targetPosition
+            }) { animationPosition in
+                print("Completed panel transition to hidden")
+            }
         }
     }
     

--- a/Aiolos/Demo/ViewController.swift
+++ b/Aiolos/Demo/ViewController.swift
@@ -132,10 +132,9 @@ extension ViewController: PanelAnimationDelegate {
                 print("Completed panel transition to hidden")
             })
         } else {
-            let targetPosition = context.targetPosition(in: self.view)
             coordinator.animateAlongsideTransition({
-                print("Animating alongside of panel transition to target position: \(targetPosition)")
-                panel.configuration.position = targetPosition
+                print("Animating alongside of panel transition to target position: \(context.targetPosition)")
+                panel.configuration.position = context.targetPosition
             }) { animationPosition in
                 print("Completed panel transition to hidden")
             }

--- a/Aiolos/Demo/ViewController.swift
+++ b/Aiolos/Demo/ViewController.swift
@@ -119,10 +119,10 @@ extension ViewController: PanelAnimationDelegate {
         return true
     }
     
-    func panel(_ panel: Panel, didMoveFrom origin: CGRect, to destination: CGRect, with coordinator: PanelTransitionCoordinator) {
+    func panel(_ panel: Panel, didMoveFrom oldFrame: CGRect, to newFrame: CGRect, with coordinator: PanelTransitionCoordinator) {
         guard let context = coordinator.direction.context else { return }
 
-        print("Panel did move to frame \(destination)")
+        print("Panel did move to frame \(newFrame)")
         
         let panelShouldHide = context.isMovingPastLeadingEdge || context.isMovingPastTrailingEdge
         if panelShouldHide {

--- a/Aiolos/Demo/ViewController.swift
+++ b/Aiolos/Demo/ViewController.swift
@@ -116,6 +116,19 @@ extension ViewController: PanelAnimationDelegate {
     }
 }
 
+// MARK: - PanelPositionDelegate
+
+extension ViewController: PanelPositionDelegate {
+    
+    func panel(_ panel: Panel, willMoveTo frame: CGRect) {
+        print("Panel will move to frame \(frame)")
+    }
+    
+    func panel(_ panel: Panel, willMoveFrom oldPosition: Panel.Configuration.Position, to newPosition: Panel.Configuration.Position) {
+        print("Panel will transition from \(oldPosition) to \(newPosition)")
+    }
+}
+
 // MARK: - Private
 
 private extension ViewController {
@@ -132,6 +145,7 @@ private extension ViewController {
 
         panelController.sizeDelegate = self
         panelController.animationDelegate = self
+        panelController.positionDelegate = self
         panelController.contentViewController = contentNavigationController
         panelController.configuration.position = self.panelPosition(for: self.traitCollection)
         panelController.configuration.margins = self.panelMargins(for: self.traitCollection)

--- a/Aiolos/Demo/ViewController.swift
+++ b/Aiolos/Demo/ViewController.swift
@@ -115,6 +115,10 @@ extension ViewController: PanelAnimationDelegate {
         })
     }
     
+    func panel(_ panel: Panel, shouldMoveTo frame: CGRect) -> Bool {
+        return true
+    }
+    
     func panel(_ panel: Panel, willMoveTo frame: CGRect) {
         print("Panel will move to frame \(frame)")
     }

--- a/Aiolos/Demo/ViewController.swift
+++ b/Aiolos/Demo/ViewController.swift
@@ -120,7 +120,7 @@ extension ViewController: PanelAnimationDelegate {
     }
     
     func panel(_ panel: Panel, didMoveFrom origin: CGRect, to destination: CGRect, with coordinator: PanelTransitionCoordinator) {
-        guard let context = coordinator.context else { return }
+        guard let context = coordinator.direction.context else { return }
 
         print("Panel did move to frame \(destination)")
         


### PR DESCRIPTION
Functionality:

- [x] Allow the panel to be dragged/flicked to the opposite side of the screen, changing its position
- [x] Make the panel move only in one direction, either horizontally or vertically
- [x] Make the horizontal pan configurable (supported positions, disabled)
- [x] Add new delegate methods related to the horizontal pan
- [x] Hide the panel when being over the edge of the screen (if allowed)
- [x] Avoid the panel being dragged over the edge of the screen (if not allowed)
- [x] Nicer animation when the panel is flicked to the other side of the screen
- [x] Take projected position into account when animating the panel movement (e.g. flicking to the other side)
- [x] Make it a bit less easy to change the side (by flicking and in the portrait mode)

Bugfixes:
- [x] Flicking the panel to the other side should result in a slower movement
- [x] Fix the bug where both vertical and horizontal handlers are triggered at the same time
- [x] Flicking the panel from over the edge of the screen should not result in it changing sides