### PR TITLE
Allow gesture recognizer customization via delegate

### DIFF
--- a/Aiolos/Aiolos/Sources/Panel.swift
+++ b/Aiolos/Aiolos/Sources/Panel.swift
@@ -33,6 +33,7 @@ public final class Panel: UIViewController {
     @objc public var isVisible: Bool { return self.parent != nil && self.animator.isTransitioningFromParent == false }
     public weak var sizeDelegate: PanelSizeDelegate?
     public weak var animationDelegate: PanelAnimationDelegate?
+    public weak var gestureRecognizerDelegate: UIGestureRecognizerDelegate?
     public weak var accessibilityDelegate: PanelAccessibilityDelegate? {
         didSet {
             guard self.accessibilityDelegate !== oldValue else { return }

--- a/Aiolos/Aiolos/Sources/PanelConfiguration.swift
+++ b/Aiolos/Aiolos/Sources/PanelConfiguration.swift
@@ -75,6 +75,7 @@ public extension Panel {
         public var gestureResizingMode: GestureResizingMode
         public var appearance: Appearance
         public var horizontalPositioningEnabled: Bool { return self.supportedPositions.count > 1 }
+        public weak var gestureRecognizerDelegate: UIGestureRecognizerDelegate?
     }
 }
 
@@ -99,7 +100,8 @@ public extension Panel.Configuration {
                                    mode: .compact,
                                    supportedModes: [.compact, .expanded, .fullHeight],
                                    gestureResizingMode: .includingContent,
-                                   appearance: appearance)
+                                   appearance: appearance,
+                                   gestureRecognizerDelegate: nil)
     }
 }
 

--- a/Aiolos/Aiolos/Sources/PanelConfiguration.swift
+++ b/Aiolos/Aiolos/Sources/PanelConfiguration.swift
@@ -75,7 +75,6 @@ public extension Panel {
         public var gestureResizingMode: GestureResizingMode
         public var appearance: Appearance
         public var horizontalPositioningEnabled: Bool { return self.supportedPositions.count > 1 }
-        public weak var gestureRecognizerDelegate: UIGestureRecognizerDelegate?
     }
 }
 
@@ -100,8 +99,7 @@ public extension Panel.Configuration {
                                    mode: .compact,
                                    supportedModes: [.compact, .expanded, .fullHeight],
                                    gestureResizingMode: .includingContent,
-                                   appearance: appearance,
-                                   gestureRecognizerDelegate: nil)
+                                   appearance: appearance)
     }
 }
 

--- a/Aiolos/Aiolos/Sources/PanelGestures.swift
+++ b/Aiolos/Aiolos/Sources/PanelGestures.swift
@@ -60,8 +60,7 @@ final class PanelGestures: NSObject {
 extension PanelGestures: UIGestureRecognizerDelegate {
 
     func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
-        if let delegate = panel.configuration.gestureRecognizerDelegate,
-           let shouldBegin = delegate.gestureRecognizerShouldBegin?(gestureRecognizer) {
+        if let shouldBegin = panel.gestureRecognizerDelegate?.gestureRecognizerShouldBegin?(gestureRecognizer) {
             return shouldBegin
         }
         
@@ -76,8 +75,7 @@ extension PanelGestures: UIGestureRecognizerDelegate {
     }
 
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
-        if let delegate = panel.configuration.gestureRecognizerDelegate,
-           let shouldRecognize = delegate.gestureRecognizer?(gestureRecognizer, shouldRecognizeSimultaneouslyWith: otherGestureRecognizer) {
+        if let shouldRecognize = panel.gestureRecognizerDelegate?.gestureRecognizer?(gestureRecognizer, shouldRecognizeSimultaneouslyWith: otherGestureRecognizer) {
             return shouldRecognize
         }
         
@@ -94,8 +92,7 @@ extension PanelGestures: UIGestureRecognizerDelegate {
             return otherGestureRecognizer == self.verticalPan
         }
 
-        if let delegate = panel.configuration.gestureRecognizerDelegate,
-           let shouldRequireFailureOf = delegate.gestureRecognizer?(gestureRecognizer, shouldRequireFailureOf: otherGestureRecognizer) {
+        if let shouldRequireFailureOf = panel.gestureRecognizerDelegate?.gestureRecognizer?(gestureRecognizer, shouldRequireFailureOf: otherGestureRecognizer) {
             return shouldRequireFailureOf
         }
         
@@ -103,8 +100,7 @@ extension PanelGestures: UIGestureRecognizerDelegate {
     }
     
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldBeRequiredToFailBy otherGestureRecognizer: UIGestureRecognizer) -> Bool {
-        if let delegate = panel.configuration.gestureRecognizerDelegate,
-           let shouldBeRequiredToFailBy = delegate.gestureRecognizer?(gestureRecognizer, shouldBeRequiredToFailBy: otherGestureRecognizer) {
+        if let shouldBeRequiredToFailBy = panel.gestureRecognizerDelegate?.gestureRecognizer?(gestureRecognizer, shouldBeRequiredToFailBy: otherGestureRecognizer) {
             return shouldBeRequiredToFailBy
         }
         
@@ -112,8 +108,7 @@ extension PanelGestures: UIGestureRecognizerDelegate {
     }
     
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive press: UIPress) -> Bool {
-        if let delegate = panel.configuration.gestureRecognizerDelegate,
-           let shouldReceivePress = delegate.gestureRecognizer?(gestureRecognizer, shouldReceive: press) {
+        if let shouldReceivePress = panel.gestureRecognizerDelegate?.gestureRecognizer?(gestureRecognizer, shouldReceive: press) {
             return shouldReceivePress
         }
         
@@ -121,8 +116,7 @@ extension PanelGestures: UIGestureRecognizerDelegate {
     }
     
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
-        if let delegate = panel.configuration.gestureRecognizerDelegate,
-            let shouldReceiveTouch = delegate.gestureRecognizer?(gestureRecognizer, shouldReceive: touch) {
+        if let shouldReceiveTouch = panel.gestureRecognizerDelegate?.gestureRecognizer?(gestureRecognizer, shouldReceive: touch) {
             return shouldReceiveTouch
         }
         

--- a/Aiolos/Aiolos/Sources/PanelGestures.swift
+++ b/Aiolos/Aiolos/Sources/PanelGestures.swift
@@ -60,6 +60,11 @@ final class PanelGestures: NSObject {
 extension PanelGestures: UIGestureRecognizerDelegate {
 
     func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        if let delegate = panel.configuration.gestureRecognizerDelegate,
+           let shouldBegin = delegate.gestureRecognizerShouldBegin?(gestureRecognizer) {
+            return shouldBegin
+        }
+        
         switch gestureRecognizer {
         case self.horizontalPan:
             return self.horizontalHandler.shouldStartPan(self.horizontalPan)
@@ -71,6 +76,11 @@ extension PanelGestures: UIGestureRecognizerDelegate {
     }
 
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        if let delegate = panel.configuration.gestureRecognizerDelegate,
+           let shouldRecognize = delegate.gestureRecognizer?(gestureRecognizer, shouldRecognizeSimultaneouslyWith: otherGestureRecognizer) {
+            return shouldRecognize
+        }
+        
         return true
     }
 
@@ -84,7 +94,39 @@ extension PanelGestures: UIGestureRecognizerDelegate {
             return otherGestureRecognizer == self.verticalPan
         }
 
+        if let delegate = panel.configuration.gestureRecognizerDelegate,
+           let shouldRequireFailureOf = delegate.gestureRecognizer?(gestureRecognizer, shouldRequireFailureOf: otherGestureRecognizer) {
+            return shouldRequireFailureOf
+        }
+        
         return false
+    }
+    
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldBeRequiredToFailBy otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        if let delegate = panel.configuration.gestureRecognizerDelegate,
+           let shouldBeRequiredToFailBy = delegate.gestureRecognizer?(gestureRecognizer, shouldBeRequiredToFailBy: otherGestureRecognizer) {
+            return shouldBeRequiredToFailBy
+        }
+        
+        return false
+    }
+    
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive press: UIPress) -> Bool {
+        if let delegate = panel.configuration.gestureRecognizerDelegate,
+           let shouldReceivePress = delegate.gestureRecognizer?(gestureRecognizer, shouldReceive: press) {
+            return shouldReceivePress
+        }
+        
+        return true
+    }
+    
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        if let delegate = panel.configuration.gestureRecognizerDelegate,
+            let shouldReceiveTouch = delegate.gestureRecognizer?(gestureRecognizer, shouldReceive: touch) {
+            return shouldReceiveTouch
+        }
+        
+        return true
     }
 }
 


### PR DESCRIPTION
Hey, so happy I found this project. Love how frictionless the panels feel!

So I needed to balance out some gesture recognizers in a more elaborate panel UI and could not find an easy way to do this. Not sure if I missed something though. Anyways. In case I did not: this might be useful. This PR adds a new var to Panel (gestureRecognizerDelegate) which allows injecting your own UIGestureRecognizerDelegate logic. Please see the GIFs below on how this makes a difference UX wise.

![withoutrecognizerdelegate](https://user-images.githubusercontent.com/699762/51856370-d4139900-232f-11e9-8cd1-c3f451ab809a.gif)![withrecognizerdelegate](https://user-images.githubusercontent.com/699762/51856377-da097a00-232f-11e9-8940-54c96e56bf86.gif)
**Without and with custom UIGestureRecognizerDelegate**

This one just overrides 
`gestureRecognizer(_ gestureRecognizer: shouldBeRequiredToFailBy:) -> Bool`
cause I don't want multiple recognizers to register at the same time. Dragging down the panel while also scrolling the calendar felt broken. Code would look like this:

```swift
class VC: UIViewController {
  ...
  let panel = Panel(configuration: configuration)
  panel.gestureRecognizerDelegate = self
  ...
}

extension VC: UIGestureRecognizerDelegate {
  
  func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldBeRequiredToFailBy otherGestureRecognizer: UIGestureRecognizer) -> Bool {
    return true
  }
}
```