### PR TITLE
Update panel’s configuration to its final position before animating the change

### DIFF
--- a/Aiolos/Aiolos/Sources/PanelConstraints.swift
+++ b/Aiolos/Aiolos/Sources/PanelConstraints.swift
@@ -145,6 +145,15 @@ internal extension PanelConstraints {
         self.isResizing = false
         self.updateSizeConstraints(for: targetSize)
     }
+
+    func prepareForHorizontalPanEndAnimation() {
+        // TODO: Better naming: Either rename the property to something more generic (isPanning|isTransitioning) or create a new one 'isMoving'
+        self.isResizing = true
+    }
+
+    func updateForHorizontalPanEndAnimationCompleted() {
+        self.isResizing = false
+    }
 }
 
 // MARK: - Private

--- a/Aiolos/Aiolos/Sources/PanelConstraints.swift
+++ b/Aiolos/Aiolos/Sources/PanelConstraints.swift
@@ -13,7 +13,7 @@ import Foundation
 final class PanelConstraints {
 
     private unowned let panel: Panel
-    private var isResizing: Bool = false
+    private var isTransitioning: Bool = false
     private lazy var keyboardLayoutGuide: KeyboardLayoutGuide = self.makeKeyboardLayoutGuide()
     private var topConstraint: NSLayoutConstraint?
     private var topConstraintMargin: CGFloat = 0.0
@@ -30,7 +30,7 @@ final class PanelConstraints {
     // MARK: - PanelConstraints
 
     func updateSizeConstraints(for size: CGSize) {
-        guard self.isResizing == false else { return }
+        guard self.isTransitioning == false else { return }
         guard let widthConstraint = self.widthConstraint, let heightConstraint = self.heightConstraint else {
             self.activateSizeConstraints(for: size)
             return
@@ -43,7 +43,7 @@ final class PanelConstraints {
     }
 
     func updatePositionConstraints(for position: Panel.Configuration.Position, margins: NSDirectionalEdgeInsets) {
-        guard self.isResizing == false else { return }
+        guard self.isTransitioning == false else { return }
         guard let view = self.panel.view else { return }
         guard let parentView = self.panel.parent?.view else { return }
 
@@ -121,38 +121,37 @@ internal extension PanelConstraints {
     }
 
     func updateForPan(with yOffset: CGFloat) {
-        self.isResizing = true
+        self.isTransitioning = true
         self.heightConstraint?.constant -= yOffset
     }
 
     func updateForPanEnd() {
         self.setTopConstraintIsRelaxed(false)
-        self.isResizing = false
+        self.isTransitioning = false
     }
 
     func prepareForPanEndAnimation() {
-        self.isResizing = true
+        self.isTransitioning = true
     }
 
     func updateForPanEndAnimation(to height: CGFloat) {
         self.heightConstraint?.constant = height
         self.panel.parent?.view.layoutIfNeeded()
-        self.isResizing = false
+        self.isTransitioning = false
     }
 
     func updateForPanCancelled(with targetSize: CGSize) {
         self.setTopConstraintIsRelaxed(false)
-        self.isResizing = false
+        self.isTransitioning = false
         self.updateSizeConstraints(for: targetSize)
     }
 
     func prepareForHorizontalPanEndAnimation() {
-        // TODO: Better naming: Either rename the property to something more generic (isPanning|isTransitioning) or create a new one 'isMoving'
-        self.isResizing = true
+        self.isTransitioning = true
     }
 
     func updateForHorizontalPanEndAnimationCompleted() {
-        self.isResizing = false
+        self.isTransitioning = false
     }
 }
 

--- a/Aiolos/Aiolos/Sources/PanelGestures.swift
+++ b/Aiolos/Aiolos/Sources/PanelGestures.swift
@@ -223,13 +223,16 @@ private extension PanelGestures {
         private func animate(to targetPosition: Panel.Configuration.Position, initialVelocity: CGFloat) {
             let targetOffset = self.offset(for: targetPosition)
             let timing = Animation.overdamped.makeTiming(with: initialVelocity)
-            
+
+            self.panel.constraints.prepareForHorizontalPanEndAnimation()
+            self.panel.configuration.position = targetPosition
             self.panel.animator.animateWithTiming(timing, animations: {
                 self.panel.view.transform = CGAffineTransform(translationX: targetOffset, y: 0)
             }, completion: {
                 self.panel.animator.performWithoutAnimation {
                     self.panel.view.transform = .identity
-                    self.panel.configuration.position = targetPosition
+                    self.panel.constraints.updateForHorizontalPanEndAnimationCompleted()
+                    self.panel.constraints.updatePositionConstraints(for: targetPosition, margins: self.panel.configuration.margins)
                 }
             })
         }


### PR DESCRIPTION
This will allow reading the panel’s new position within animateAlongsideTransiting block and make it consistent with how changing panel’s mode work.