### PR TITLE
Add ability for the contentViewController to take up the panel's frames and ignore handle section

### DIFF
--- a/Aiolos/Aiolos/Sources/Panel.swift
+++ b/Aiolos/Aiolos/Sources/Panel.swift
@@ -94,7 +94,7 @@ public extension Panel {
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 
-        if configuration.shouldShowHandleSpace {
+        if configuration.shouldHideHandleSpace {
             resizeHandle.frame = .zero
             separatorView.frame = .zero
             panelView.frame = self.view.bounds

--- a/Aiolos/Aiolos/Sources/Panel.swift
+++ b/Aiolos/Aiolos/Sources/Panel.swift
@@ -93,12 +93,13 @@ public extension Panel {
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-
-        if configuration.shouldHideHandleSpace {
-            resizeHandle.frame = .zero
-            separatorView.frame = .zero
+        
+        switch configuration.appearance.resizeHandleAppearence {
+        case .hidden:
+            resizeHandle.frame = .null
+            separatorView.frame = .null
             panelView.frame = self.view.bounds
-        } else {
+        case .visible:
             let (resizeFrame, panelFrame) = self.view.bounds.divided(atDistance: ResizeHandle.Constants.height, from: .minYEdge)
             self.resizeHandle.frame = resizeFrame
             self.panelView.frame = panelFrame

--- a/Aiolos/Aiolos/Sources/Panel.swift
+++ b/Aiolos/Aiolos/Sources/Panel.swift
@@ -95,8 +95,9 @@ public extension Panel {
         super.viewDidLayoutSubviews()
 
         if configuration.shouldShowHandleSpace {
-            self.resizeHandle.frame = .zero
-            self.panelView.frame = self.view.bounds
+            resizeHandle.frame = .zero
+            separatorView.frame = .zero
+            panelView.frame = self.view.bounds
         } else {
             let (resizeFrame, panelFrame) = self.view.bounds.divided(atDistance: ResizeHandle.Constants.height, from: .minYEdge)
             self.resizeHandle.frame = resizeFrame

--- a/Aiolos/Aiolos/Sources/Panel.swift
+++ b/Aiolos/Aiolos/Sources/Panel.swift
@@ -94,16 +94,21 @@ public extension Panel {
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 
-        let (resizeFrame, panelFrame) = self.view.bounds.divided(atDistance: ResizeHandle.Constants.height, from: .minYEdge)
-        self.resizeHandle.frame = resizeFrame
-        self.panelView.frame = panelFrame
-
-        let lineWidth = 1.0 / UIScreen.main.scale
-        var dividerFrame = panelFrame.insetBy(dx: lineWidth, dy: 0.0)
-        dividerFrame.size.height = lineWidth
-        dividerFrame.origin.y -= dividerFrame.size.height / 2.0
-        self.separatorView.frame = dividerFrame
-
+        if configuration.shouldShowHandleSpace {
+            self.resizeHandle.frame = .zero
+            self.panelView.frame = self.view.bounds
+        } else {
+            let (resizeFrame, panelFrame) = self.view.bounds.divided(atDistance: ResizeHandle.Constants.height, from: .minYEdge)
+            self.resizeHandle.frame = resizeFrame
+            self.panelView.frame = panelFrame
+            
+            let lineWidth = 1.0 / UIScreen.main.scale
+            var dividerFrame = panelFrame.insetBy(dx: lineWidth, dy: 0.0)
+            dividerFrame.size.height = lineWidth
+            dividerFrame.origin.y -= dividerFrame.size.height / 2.0
+            self.separatorView.frame = dividerFrame
+        }
+        
         self.fixNavigationBarLayoutMargins()
     }
 

--- a/Aiolos/Aiolos/Sources/PanelConfiguration.swift
+++ b/Aiolos/Aiolos/Sources/PanelConfiguration.swift
@@ -74,6 +74,7 @@ public extension Panel {
         public var supportedModes: Set<Mode>
         public var gestureResizingMode: GestureResizingMode
         public var appearance: Appearance
+        public var shouldShowHandleSpace: Bool = true
         public var horizontalPositioningEnabled: Bool { return self.supportedPositions.count > 1 }
     }
 }
@@ -99,7 +100,8 @@ public extension Panel.Configuration {
                                    mode: .compact,
                                    supportedModes: [.compact, .expanded, .fullHeight],
                                    gestureResizingMode: .includingContent,
-                                   appearance: appearance)
+                                   appearance: appearance,
+                                   shouldShowHandleSpace: true)
     }
 }
 

--- a/Aiolos/Aiolos/Sources/PanelConfiguration.swift
+++ b/Aiolos/Aiolos/Sources/PanelConfiguration.swift
@@ -74,7 +74,7 @@ public extension Panel {
         public var supportedModes: Set<Mode>
         public var gestureResizingMode: GestureResizingMode
         public var appearance: Appearance
-        public var shouldShowHandleSpace: Bool = true
+        public var shouldHideHandleSpace: Bool = true
         public var horizontalPositioningEnabled: Bool { return self.supportedPositions.count > 1 }
     }
 }
@@ -101,7 +101,7 @@ public extension Panel.Configuration {
                                    supportedModes: [.compact, .expanded, .fullHeight],
                                    gestureResizingMode: .includingContent,
                                    appearance: appearance,
-                                   shouldShowHandleSpace: true)
+                                   shouldHideHandleSpace: true)
     }
 }
 

--- a/Aiolos/Aiolos/Sources/PanelConfiguration.swift
+++ b/Aiolos/Aiolos/Sources/PanelConfiguration.swift
@@ -56,14 +56,18 @@ public extension Panel {
         public struct Appearance {
             public var visualEffect: UIVisualEffect?
             public var borderColor: UIColor
-            public var resizeHandleColor: UIColor
-            public var resizeHandleBackgroundColor: UIColor
             public var separatorColor: UIColor
             public var cornerRadius: CGFloat
             public var maskedCorners: CACornerMask
             public var shadowColor: UIColor
             public var shadowOpacity: Float
             public var shadowOffset: UIOffset
+            public var resizeHandleAppearence: ResizeHandleAppearance
+            
+            public enum ResizeHandleAppearance {
+                case hidden
+                case visible(foregroundColor: UIColor, backgroundColor: UIColor)
+            }
         }
 
         public var position: Position
@@ -74,7 +78,6 @@ public extension Panel {
         public var supportedModes: Set<Mode>
         public var gestureResizingMode: GestureResizingMode
         public var appearance: Appearance
-        public var shouldHideHandleSpace: Bool = true
         public var horizontalPositioningEnabled: Bool { return self.supportedPositions.count > 1 }
     }
 }
@@ -84,14 +87,13 @@ public extension Panel.Configuration {
     static var `default`: Panel.Configuration {
         let appearance = Appearance(visualEffect: UIBlurEffect(style: .extraLight),
                                     borderColor: UIColor.gray.withAlphaComponent(0.5),
-                                    resizeHandleColor: UIColor.gray.withAlphaComponent(0.3),
-                                    resizeHandleBackgroundColor: .white,
                                     separatorColor: UIColor.gray.withAlphaComponent(0.5),
                                     cornerRadius: 10.0,
                                     maskedCorners: [.layerMinXMinYCorner, .layerMinXMaxYCorner, .layerMaxXMinYCorner, .layerMaxXMaxYCorner],
                                     shadowColor: .black,
                                     shadowOpacity: 0.15,
-                                    shadowOffset: UIOffset(horizontal: 0.0, vertical: 1.0))
+                                    shadowOffset: UIOffset(horizontal: 0.0, vertical: 1.0),
+                                    resizeHandleAppearence: .visible(foregroundColor: UIColor.gray.withAlphaComponent(0.3), backgroundColor: .white))
 
         return Panel.Configuration(position: .bottom,
                                    positionLogic: PositionLogic.respectAllSafeAreas,
@@ -100,8 +102,7 @@ public extension Panel.Configuration {
                                    mode: .compact,
                                    supportedModes: [.compact, .expanded, .fullHeight],
                                    gestureResizingMode: .includingContent,
-                                   appearance: appearance,
-                                   shouldHideHandleSpace: true)
+                                   appearance: appearance)
     }
 }
 

--- a/Aiolos/Aiolos/Sources/ResizeHandle.swift
+++ b/Aiolos/Aiolos/Sources/ResizeHandle.swift
@@ -60,8 +60,12 @@ public final class ResizeHandle: UIView {
     // MARK: - ResizeHandle
 
     func configure(with configuration: Panel.Configuration) {
-        self.handleColor = configuration.appearance.resizeHandleColor
-        self.backgroundColor = configuration.appearance.resizeHandleBackgroundColor
+        guard case let .visible(foregroundColor, backgroundColor) = configuration.appearance.resizeHandleAppearence else {
+           return
+        }
+        
+        self.handleColor = foregroundColor
+        self.backgroundColor = backgroundColor
         self.resizeHandle.opacity = configuration.gestureResizingMode != .disabled && configuration.supportedModes.count > 1 ? 1.0 : 0.2
     }
 }

--- a/Aiolos/Demo/ViewController.swift
+++ b/Aiolos/Demo/ViewController.swift
@@ -176,6 +176,9 @@ private extension ViewController {
             return NSDirectionalEdgeInsets(top: 20.0, leading: horizontalMargin, bottom: 0.0, trailing: horizontalMargin)
         }
 
+        // Toggle here to show/hide the resize handle
+//        configuration.appearance.resizeHandleAppearence = .hidden
+        
         configuration.appearance.separatorColor = .white
         configuration.position = panelPosition
         configuration.margins = panelMargins


### PR DESCRIPTION
This adds a `shouldHideHandleSpace` property to the `Configuration` struct that allows the `contentViewController` to take up all the space in the `Panel`

Example:
![simulator screen shot - iphone x - 2019-02-01 at 13 38 39](https://user-images.githubusercontent.com/2848487/52151786-10ddd980-2629-11e9-8b0f-5292fd4432a4.png)
