### PR TITLE
Do not use margins for panel height calculation

### DIFF
--- a/Aiolos/Aiolos/Sources/Panel.swift
+++ b/Aiolos/Aiolos/Sources/Panel.swift
@@ -221,7 +221,7 @@ internal extension Panel {
             height = 0.0
         case .fullHeight:
             let screen = parent.view.window?.screen ?? UIScreen.main
-            height = screen.fixedCoordinateSpace.bounds.height - self.configuration.margins.top - self.configuration.margins.bottom
+            height = screen.fixedCoordinateSpace.bounds.height
         default:
             height = delegateSize.height
         }


### PR DESCRIPTION
This fixes a bug on iPad in portrait mode where the panel doesn't grow to its full height after the a vertical margin was changed