### PR TITLE
[WIP] Split up PanelAnimationDelegate

### DIFF
--- a/Aiolos/Aiolos/Sources/Panel.swift
+++ b/Aiolos/Aiolos/Sources/Panel.swift
@@ -36,7 +36,7 @@ public final class Panel: UIViewController {
     public weak var repositionDelegate: PanelRepositionDelegate?
 
     @available(*, deprecated, message: "This property will be removed. Use 'resizeDelegate' and 'repositionDelegate' properties instead.")
-    public weak var animationDelegate: PanelAnimationDelegate? {
+    public weak var animationDelegate: (PanelResizeDelegate & PanelRepositionDelegate)? {
         didSet {
             self.resizeDelegate = animationDelegate
             self.repositionDelegate = animationDelegate

--- a/Aiolos/Aiolos/Sources/Panel.swift
+++ b/Aiolos/Aiolos/Sources/Panel.swift
@@ -32,7 +32,8 @@ public final class Panel: UIViewController {
     @objc private(set) public lazy var panelView: PanelView = self.makePanelView()
     @objc public var isVisible: Bool { return self.parent != nil && self.animator.isTransitioningFromParent == false }
     public weak var sizeDelegate: PanelSizeDelegate?
-    public weak var animationDelegate: PanelAnimationDelegate?
+    public weak var resizeDelegate: PanelResizeDelegate?
+    public weak var repositionDelegate: PanelRepositionDelegate?
     public weak var gestureDelegate: UIGestureRecognizerDelegate?
     public weak var accessibilityDelegate: PanelAccessibilityDelegate? {
         didSet {

--- a/Aiolos/Aiolos/Sources/Panel.swift
+++ b/Aiolos/Aiolos/Sources/Panel.swift
@@ -34,14 +34,6 @@ public final class Panel: UIViewController {
     public weak var sizeDelegate: PanelSizeDelegate?
     public weak var resizeDelegate: PanelResizeDelegate?
     public weak var repositionDelegate: PanelRepositionDelegate?
-
-    @available(*, deprecated, message: "This property will be removed. Use 'resizeDelegate' and 'repositionDelegate' properties instead.")
-    public weak var animationDelegate: (PanelResizeDelegate & PanelRepositionDelegate)? {
-        didSet {
-            self.resizeDelegate = animationDelegate
-            self.repositionDelegate = animationDelegate
-        }
-    }
     public weak var gestureDelegate: UIGestureRecognizerDelegate?
     public weak var accessibilityDelegate: PanelAccessibilityDelegate? {
         didSet {

--- a/Aiolos/Aiolos/Sources/Panel.swift
+++ b/Aiolos/Aiolos/Sources/Panel.swift
@@ -34,6 +34,14 @@ public final class Panel: UIViewController {
     public weak var sizeDelegate: PanelSizeDelegate?
     public weak var resizeDelegate: PanelResizeDelegate?
     public weak var repositionDelegate: PanelRepositionDelegate?
+
+    @available(*, deprecated, message: "This property will be removed. Use 'resizeDelegate' and 'repositionDelegate' properties instead.")
+    public weak var animationDelegate: PanelAnimationDelegate? {
+        didSet {
+            self.resizeDelegate = animationDelegate
+            self.repositionDelegate = animationDelegate
+        }
+    }
     public weak var gestureDelegate: UIGestureRecognizerDelegate?
     public weak var accessibilityDelegate: PanelAccessibilityDelegate? {
         didSet {

--- a/Aiolos/Aiolos/Sources/PanelAnimator.swift
+++ b/Aiolos/Aiolos/Sources/PanelAnimator.swift
@@ -61,6 +61,13 @@ final class PanelAnimator {
         animator.finishAnimation(at: .end)
     }
 
+    func notifyDelegateOfResizing() {
+        guard let resizeDelegate = self.panel.resizeDelegate else { return }
+        guard self.panel.isVisible else { return }
+
+        resizeDelegate.panelDidStartResizing(self.panel)
+    }
+
     func notifyDelegateOfTransition(to size: CGSize) {
         guard let animationDelegate = self.panel.resizeDelegate else { return }
         guard self.panel.isVisible else { return }

--- a/Aiolos/Aiolos/Sources/PanelAnimator.swift
+++ b/Aiolos/Aiolos/Sources/PanelAnimator.swift
@@ -61,47 +61,54 @@ final class PanelAnimator {
         animator.finishAnimation(at: .end)
     }
 
-    func notifyDelegateOfTransition(in direction: Panel.Direction) {
-        guard let animationDelegate = self.panel.animationDelegate else { return }
+    func notifyDelegateOfResizing() {
+        guard let resizeDelegate = self.panel.resizeDelegate else { return }
         guard self.panel.isVisible else { return }
 
-        animationDelegate.panel(self.panel, didStartTransitioningIn: .horizontal)
+        resizeDelegate.panelDidStartResizing(self.panel)
     }
 
     func notifyDelegateOfTransition(to size: CGSize) {
-        guard let animationDelegate = self.panel.animationDelegate else { return }
+        guard let animationDelegate = self.panel.resizeDelegate else { return }
         guard self.panel.isVisible else { return }
 
         animationDelegate.panel(self.panel, willTransitionTo: size)
-        if let contentViewController = self.panel.contentViewController as? PanelAnimationDelegate {
+        if let contentViewController = self.panel.contentViewController as? PanelResizeDelegate {
             contentViewController.panel(self.panel, willTransitionTo: size)
         }
     }
 
     func notifyDelegateOfTransition(from oldMode: Panel.Configuration.Mode?, to newMode: Panel.Configuration.Mode) {
-        guard let animationDelegate = self.panel.animationDelegate else { return }
+        guard let animationDelegate = self.panel.resizeDelegate else { return }
         guard self.panel.isVisible else { return }
 
         let transitionCoordinator = PanelTransitionCoordinator(animator: self, direction: .vertical)
         animationDelegate.panel(self.panel, willTransitionFrom: oldMode, to: newMode, with: transitionCoordinator)
-        if let contentViewController = self.panel.contentViewController as? PanelAnimationDelegate {
+        if let contentViewController = self.panel.contentViewController as? PanelResizeDelegate {
             contentViewController.panel(self.panel, willTransitionFrom: oldMode, to: newMode, with: transitionCoordinator)
         }
     }
-    
+
+    func notifyDelegateOfRepositioning() {
+        guard let repositionDelegate = self.panel.repositionDelegate else { return }
+        guard self.panel.isVisible else { return }
+
+        repositionDelegate.panelDidStartMoving(self.panel)
+    }
+
     func askDelegateAboutMove(to frame: CGRect) -> Bool {
-        guard let animationDelegate = self.panel.animationDelegate else { return false }
+        guard let repositionDelegate = self.panel.repositionDelegate else { return false }
         guard self.panel.isVisible else { return false }
         
-        return animationDelegate.panel(self.panel, shouldMoveTo: frame)
+        return repositionDelegate.panel(self.panel, shouldMoveTo: frame)
     }
     
     func notifyDelegateOfMove(from oldFrame: CGRect, to newFrame: CGRect, context: PanelTransitionCoordinator.HorizontalTransitionContext) -> PanelTransitionCoordinator.Instruction {
-        guard let animationDelegate = self.panel.animationDelegate else { return .none }
+        guard let repositionDelegate = self.panel.repositionDelegate else { return .none }
         guard self.panel.isVisible else { return .none }
         
         let transitionCoordinator = PanelTransitionCoordinator(animator: self, direction: .horizontal(context: context))
-        return animationDelegate.panel(self.panel, didMoveFrom: oldFrame, to: newFrame, with: transitionCoordinator)
+        return repositionDelegate.panel(self.panel, didMoveFrom: oldFrame, to: newFrame, with: transitionCoordinator)
     }
 }
 

--- a/Aiolos/Aiolos/Sources/PanelAnimator.swift
+++ b/Aiolos/Aiolos/Sources/PanelAnimator.swift
@@ -66,6 +66,7 @@ final class PanelAnimator {
         guard self.panel.isVisible else { return }
 
         resizeDelegate.panelDidStartResizing(self.panel)
+        self.panel.animationDelegate?.panel(self.panel, didStartTransitioningIn: .vertical)
     }
 
     func notifyDelegateOfTransition(to size: CGSize) {
@@ -94,6 +95,7 @@ final class PanelAnimator {
         guard self.panel.isVisible else { return }
 
         repositionDelegate.panelDidStartMoving(self.panel)
+        self.panel.animationDelegate?.panel(self.panel, didStartTransitioningIn: .horizontal)
     }
 
     func askDelegateAboutMove(to frame: CGRect) -> Bool {

--- a/Aiolos/Aiolos/Sources/PanelAnimator.swift
+++ b/Aiolos/Aiolos/Sources/PanelAnimator.swift
@@ -66,7 +66,6 @@ final class PanelAnimator {
         guard self.panel.isVisible else { return }
 
         resizeDelegate.panelDidStartResizing(self.panel)
-        self.panel.animationDelegate?.panel(self.panel, didStartTransitioningIn: .vertical)
     }
 
     func notifyDelegateOfTransition(to size: CGSize) {
@@ -95,7 +94,6 @@ final class PanelAnimator {
         guard self.panel.isVisible else { return }
 
         repositionDelegate.panelDidStartMoving(self.panel)
-        self.panel.animationDelegate?.panel(self.panel, didStartTransitioningIn: .horizontal)
     }
 
     func askDelegateAboutMove(to frame: CGRect) -> Bool {

--- a/Aiolos/Aiolos/Sources/PanelAnimator.swift
+++ b/Aiolos/Aiolos/Sources/PanelAnimator.swift
@@ -61,13 +61,6 @@ final class PanelAnimator {
         animator.finishAnimation(at: .end)
     }
 
-    func notifyDelegateOfResizing() {
-        guard let resizeDelegate = self.panel.resizeDelegate else { return }
-        guard self.panel.isVisible else { return }
-
-        resizeDelegate.panelDidStartResizing(self.panel)
-    }
-
     func notifyDelegateOfTransition(to size: CGSize) {
         guard let animationDelegate = self.panel.resizeDelegate else { return }
         guard self.panel.isVisible else { return }

--- a/Aiolos/Aiolos/Sources/PanelDelegate.swift
+++ b/Aiolos/Aiolos/Sources/PanelDelegate.swift
@@ -41,6 +41,13 @@ public protocol PanelRepositionDelegate: AnyObject {
     func panel(_ panel: Panel, didMoveFrom oldFrame: CGRect, to newFrame: CGRect, with coordinator: PanelTransitionCoordinator) -> PanelTransitionCoordinator.Instruction
 }
 
+public protocol PanelAnimationDelegate: PanelResizeDelegate, PanelRepositionDelegate {
+
+    /// Tells the delegate that the `panel` has started transition in a specific direction
+    @available(*, deprecated, message: "Protocol PanelAnimationDelegate will be removed. Use PanelResizeDelegate and PanelRepositionDelegate instead.")
+    func panel(_ panel: Panel, didStartTransitioningIn direction: Panel.Direction)
+}
+
 public protocol PanelAccessibilityDelegate: AnyObject {
 
     /// Asks the delegate for the accessibility label of the resize handle

--- a/Aiolos/Aiolos/Sources/PanelDelegate.swift
+++ b/Aiolos/Aiolos/Sources/PanelDelegate.swift
@@ -29,6 +29,13 @@ public protocol PanelResizeDelegate: AnyObject {
     func panel(_ panel: Panel, willTransitionFrom oldMode: Panel.Configuration.Mode?, to newMode: Panel.Configuration.Mode, with coordinator: PanelTransitionCoordinator)
 }
 
+public extension PanelResizeDelegate {
+
+    func panelDidStartResizing(_ panel: Panel) {
+        // Do nothing
+    }
+}
+
 public protocol PanelRepositionDelegate: AnyObject {
 
     /// Tells the delegate that the `panel` has started moving

--- a/Aiolos/Aiolos/Sources/PanelDelegate.swift
+++ b/Aiolos/Aiolos/Sources/PanelDelegate.swift
@@ -19,7 +19,7 @@ public protocol PanelSizeDelegate: AnyObject {
 
 public protocol PanelResizeDelegate: AnyObject {
 
-    /// Tells the delegate that the `panel` has started transitioning vertically
+    /// Tells the delegate that the `panel` has started resizing
     func panelDidStartResizing(_ panel: Panel)
 
     /// Tells the delegate that the `panel` is transitioning to a specific size
@@ -31,7 +31,7 @@ public protocol PanelResizeDelegate: AnyObject {
 
 public protocol PanelRepositionDelegate: AnyObject {
 
-    /// Tells the delegate that the `panel` has started transitioning horizontally
+    /// Tells the delegate that the `panel` has started moving
     func panelDidStartMoving(_ panel: Panel)
 
     /// Asks the delegate if the `panel` can move to a specific frame

--- a/Aiolos/Aiolos/Sources/PanelDelegate.swift
+++ b/Aiolos/Aiolos/Sources/PanelDelegate.swift
@@ -48,6 +48,13 @@ public protocol PanelRepositionDelegate: AnyObject {
     func panel(_ panel: Panel, didMoveFrom oldFrame: CGRect, to newFrame: CGRect, with coordinator: PanelTransitionCoordinator) -> PanelTransitionCoordinator.Instruction
 }
 
+public extension PanelRepositionDelegate {
+
+    func panelDidStartMoving(_ panel: Panel) {
+        // Do nothing
+    }
+}
+
 @available(*, deprecated, message: "Use protocols PanelResizeDelegate and PanelRepositionDelegate instead.")
 public typealias PanelAnimationDelegate = PanelResizeDelegate & PanelRepositionDelegate
 

--- a/Aiolos/Aiolos/Sources/PanelDelegate.swift
+++ b/Aiolos/Aiolos/Sources/PanelDelegate.swift
@@ -29,13 +29,6 @@ public protocol PanelResizeDelegate: AnyObject {
     func panel(_ panel: Panel, willTransitionFrom oldMode: Panel.Configuration.Mode?, to newMode: Panel.Configuration.Mode, with coordinator: PanelTransitionCoordinator)
 }
 
-public extension PanelResizeDelegate {
-
-    func panelDidStartResizing(_ panel: Panel) {
-        // Do nothing
-    }
-}
-
 public protocol PanelRepositionDelegate: AnyObject {
 
     /// Tells the delegate that the `panel` has started moving
@@ -46,13 +39,6 @@ public protocol PanelRepositionDelegate: AnyObject {
 
     /// Tells the delegate that the `panel` did move to a specific frame
     func panel(_ panel: Panel, didMoveFrom oldFrame: CGRect, to newFrame: CGRect, with coordinator: PanelTransitionCoordinator) -> PanelTransitionCoordinator.Instruction
-}
-
-public extension PanelRepositionDelegate {
-
-    func panelDidStartMoving(_ panel: Panel) {
-        // Do nothing
-    }
 }
 
 @available(*, deprecated, message: "Use protocols PanelResizeDelegate and PanelRepositionDelegate instead.")

--- a/Aiolos/Aiolos/Sources/PanelDelegate.swift
+++ b/Aiolos/Aiolos/Sources/PanelDelegate.swift
@@ -41,9 +41,6 @@ public protocol PanelRepositionDelegate: AnyObject {
     func panel(_ panel: Panel, didMoveFrom oldFrame: CGRect, to newFrame: CGRect, with coordinator: PanelTransitionCoordinator) -> PanelTransitionCoordinator.Instruction
 }
 
-@available(*, deprecated, message: "Use protocols PanelResizeDelegate and PanelRepositionDelegate instead.")
-public typealias PanelAnimationDelegate = PanelResizeDelegate & PanelRepositionDelegate
-
 public protocol PanelAccessibilityDelegate: AnyObject {
 
     /// Asks the delegate for the accessibility label of the resize handle

--- a/Aiolos/Aiolos/Sources/PanelDelegate.swift
+++ b/Aiolos/Aiolos/Sources/PanelDelegate.swift
@@ -19,6 +19,9 @@ public protocol PanelSizeDelegate: AnyObject {
 
 public protocol PanelResizeDelegate: AnyObject {
 
+    /// Tells the delegate that the `panel` has started resizing
+    func panelDidStartResizing(_ panel: Panel)
+
     /// Tells the delegate that the `panel` is transitioning to a specific size
     func panel(_ panel: Panel, willTransitionTo size: CGSize)
 

--- a/Aiolos/Aiolos/Sources/PanelDelegate.swift
+++ b/Aiolos/Aiolos/Sources/PanelDelegate.swift
@@ -17,16 +17,22 @@ public protocol PanelSizeDelegate: AnyObject {
     func panel(_ panel: Panel, sizeForMode mode: Panel.Configuration.Mode) -> CGSize
 }
 
-public protocol PanelAnimationDelegate: AnyObject {
+public protocol PanelResizeDelegate: AnyObject {
 
-    /// Tells the delegate that the `panel` has started transition in a specific direction
-    func panel(_ panel: Panel, didStartTransitioningIn direction: Panel.Direction)
+    /// Tells the delegate that the `panel` has started transitioning vertically
+    func panelDidStartResizing(_ panel: Panel)
 
     /// Tells the delegate that the `panel` is transitioning to a specific size
     func panel(_ panel: Panel, willTransitionTo size: CGSize)
 
     /// Tells the delegate that the `panel` is transitioning to a specific mode
     func panel(_ panel: Panel, willTransitionFrom oldMode: Panel.Configuration.Mode?, to newMode: Panel.Configuration.Mode, with coordinator: PanelTransitionCoordinator)
+}
+
+public protocol PanelRepositionDelegate: AnyObject {
+
+    /// Tells the delegate that the `panel` has started transitioning horizontally
+    func panelDidStartMoving(_ panel: Panel)
 
     /// Asks the delegate if the `panel` can move to a specific frame
     func panel(_ panel: Panel, shouldMoveTo frame: CGRect) -> Bool

--- a/Aiolos/Aiolos/Sources/PanelDelegate.swift
+++ b/Aiolos/Aiolos/Sources/PanelDelegate.swift
@@ -19,9 +19,6 @@ public protocol PanelSizeDelegate: AnyObject {
 
 public protocol PanelResizeDelegate: AnyObject {
 
-    /// Tells the delegate that the `panel` has started resizing
-    func panelDidStartResizing(_ panel: Panel)
-
     /// Tells the delegate that the `panel` is transitioning to a specific size
     func panel(_ panel: Panel, willTransitionTo size: CGSize)
 

--- a/Aiolos/Aiolos/Sources/PanelDelegate.swift
+++ b/Aiolos/Aiolos/Sources/PanelDelegate.swift
@@ -41,12 +41,8 @@ public protocol PanelRepositionDelegate: AnyObject {
     func panel(_ panel: Panel, didMoveFrom oldFrame: CGRect, to newFrame: CGRect, with coordinator: PanelTransitionCoordinator) -> PanelTransitionCoordinator.Instruction
 }
 
-public protocol PanelAnimationDelegate: PanelResizeDelegate, PanelRepositionDelegate {
-
-    /// Tells the delegate that the `panel` has started transition in a specific direction
-    @available(*, deprecated, message: "Protocol PanelAnimationDelegate will be removed. Use PanelResizeDelegate and PanelRepositionDelegate instead.")
-    func panel(_ panel: Panel, didStartTransitioningIn direction: Panel.Direction)
-}
+@available(*, deprecated, message: "Use protocols PanelResizeDelegate and PanelRepositionDelegate instead.")
+public typealias PanelAnimationDelegate = PanelResizeDelegate & PanelRepositionDelegate
 
 public protocol PanelAccessibilityDelegate: AnyObject {
 

--- a/Aiolos/Aiolos/Sources/PanelGestures.swift
+++ b/Aiolos/Aiolos/Sources/PanelGestures.swift
@@ -365,6 +365,8 @@ private extension PanelGestures {
                 }
             }
 
+            self.panel.animator.notifyDelegateOfResizing()
+
             return true
         }
         

--- a/Aiolos/Aiolos/Sources/PanelGestures.swift
+++ b/Aiolos/Aiolos/Sources/PanelGestures.swift
@@ -365,8 +365,6 @@ private extension PanelGestures {
                 }
             }
 
-            self.panel.animator.notifyDelegateOfResizing()
-
             return true
         }
         

--- a/Aiolos/Aiolos/Sources/PanelGestures.swift
+++ b/Aiolos/Aiolos/Sources/PanelGestures.swift
@@ -165,7 +165,7 @@ private extension PanelGestures {
         }
         
         private func handlePanStarted(_ pan: UIPanGestureRecognizer) {
-            self.panel.animator.notifyDelegateOfTransition(in: .horizontal)
+            self.panel.animator.notifyDelegateOfRepositioning()
             self.gestures.updateResizeHandle()
         }
         
@@ -365,7 +365,7 @@ private extension PanelGestures {
                 }
             }
 
-            self.panel.animator.notifyDelegateOfTransition(in: .vertical)
+            self.panel.animator.notifyDelegateOfResizing()
 
             return true
         }

--- a/Aiolos/Demo/ViewController.swift
+++ b/Aiolos/Demo/ViewController.swift
@@ -98,12 +98,11 @@ extension ViewController: PanelSizeDelegate {
     }
 }
 
-// MARK: - PanelAnimationDelegate
+// MARK: - PanelResizeDelegate
 
-extension ViewController: PanelAnimationDelegate {
-
-    func panel(_ panel: Panel, didStartTransitioningIn direction: Panel.Direction) {
-        print("Panel did start transitioning in \(direction) direction")
+extension ViewController: PanelResizeDelegate {
+    func panelDidStartResizing(_ panel: Panel) {
+        print("Panel did start resizing")
     }
 
     func panel(_ panel: Panel, willTransitionTo size: CGSize) {
@@ -120,16 +119,24 @@ extension ViewController: PanelAnimationDelegate {
             print("Completed panel transition to \(newMode)")
         })
     }
-    
+}
+
+// MARK: - PanelRepositionDelegate
+
+extension ViewController: PanelRepositionDelegate {
+    func panelDidStartMoving(_ panel: Panel) {
+        print("Panel did start moving")
+    }
+
     func panel(_ panel: Panel, shouldMoveTo frame: CGRect) -> Bool {
         return true
     }
-    
+
     func panel(_ panel: Panel, didMoveFrom oldFrame: CGRect, to newFrame: CGRect, with coordinator: PanelTransitionCoordinator) -> PanelTransitionCoordinator.Instruction {
         guard let context = coordinator.direction.context else { return .none }
 
         print("Panel did move to frame \(newFrame)")
-        
+
         let panelShouldHide = context.isMovingPastLeadingEdge || context.isMovingPastTrailingEdge
         if panelShouldHide {
             return .hide
@@ -138,7 +145,6 @@ extension ViewController: PanelAnimationDelegate {
         }
     }
 }
-
 
 // MARK: - Private
 
@@ -154,7 +160,8 @@ private extension ViewController {
         contentNavigationController.view.bringSubviewToFront(contentNavigationController.navigationBar)
 
         panelController.sizeDelegate = self
-        panelController.animationDelegate = self
+        panelController.resizeDelegate = self
+        panelController.repositionDelegate = self
         panelController.contentViewController = contentNavigationController
 
         return panelController

--- a/Aiolos/Demo/ViewController.swift
+++ b/Aiolos/Demo/ViewController.swift
@@ -102,10 +102,6 @@ extension ViewController: PanelSizeDelegate {
 
 extension ViewController: PanelResizeDelegate {
 
-    func panelDidStartResizing(_ panel: Panel) {
-        print("Panel did start resizing")
-    }
-
     func panel(_ panel: Panel, willTransitionTo size: CGSize) {
         print("Panel will transition to size \(size)")
     }

--- a/Aiolos/Demo/ViewController.swift
+++ b/Aiolos/Demo/ViewController.swift
@@ -102,6 +102,10 @@ extension ViewController: PanelSizeDelegate {
 
 extension ViewController: PanelResizeDelegate {
 
+    func panelDidStartResizing(_ panel: Panel) {
+        print("Panel did start resizing")
+    }
+
     func panel(_ panel: Panel, willTransitionTo size: CGSize) {
         print("Panel will transition to size \(size)")
     }

--- a/Aiolos/Demo/ViewController.swift
+++ b/Aiolos/Demo/ViewController.swift
@@ -101,6 +101,7 @@ extension ViewController: PanelSizeDelegate {
 // MARK: - PanelResizeDelegate
 
 extension ViewController: PanelResizeDelegate {
+
     func panelDidStartResizing(_ panel: Panel) {
         print("Panel did start resizing")
     }
@@ -124,6 +125,7 @@ extension ViewController: PanelResizeDelegate {
 // MARK: - PanelRepositionDelegate
 
 extension ViewController: PanelRepositionDelegate {
+
     func panelDidStartMoving(_ panel: Panel) {
         print("Panel did start moving")
     }


### PR DESCRIPTION
Split PanelAnimationDelegate up to PanelResizeDelegate and PanelRepositionDelegate. This allows the clients to implement only the delegate methods they are interested in, resulting in less boilerplate code.