### PR TITLE
Prevent the delegate from being notified if not necessary 

### DIFF
--- a/Aiolos/Aiolos/Sources/PanelGestures.swift
+++ b/Aiolos/Aiolos/Sources/PanelGestures.swift
@@ -425,7 +425,6 @@ private extension PanelGestures {
             self.cleanUp(pan: pan)
             
             let size = self.panel.size(for: originalMode)
-            self.panel.animator.notifyDelegateOfTransition(from: originalMode, to: originalMode)
             self.panel.constraints.updateForPanCancelled(with: size)
             if currentHeight != size.height {
                 self.panel.animator.notifyDelegateOfTransition(to: size)


### PR DESCRIPTION
Prevent the delegate from being notified if the vertical gesture was cancelled (e.g. due to a horizontal pan) and the mode wasn’t changed.