### PR TITLE
Prevent gestures from being cancelled when not necessary

### DIFF
--- a/Aiolos/Aiolos/Sources/Panel.swift
+++ b/Aiolos/Aiolos/Sources/Panel.swift
@@ -341,6 +341,7 @@ private extension Panel {
         self.panelView.configure(with: newConfiguration)
         self.resizeHandle.configure(with: newConfiguration)
         self.separatorView.configure(with: newConfiguration)
+        self.gestures.configure(with: newConfiguration)
 
         let modeChanged = oldConfiguration.mode != newConfiguration.mode
         let positionChanged = oldConfiguration.position != newConfiguration.position
@@ -350,7 +351,7 @@ private extension Panel {
         let horizontalPositioningChanged = oldConfiguration.isHorizontalPositioningEnabled != newConfiguration.isHorizontalPositioningEnabled
 
         if modeChanged || positionChanged || marginsChanged || positionLogicChanged || gestureResizingModeChanged || horizontalPositioningChanged {
-            self.gestures.configure(with: newConfiguration)
+            self.gestures.cancel()
         }
 
         if modeChanged || positionChanged {

--- a/Aiolos/Aiolos/Sources/Panel.swift
+++ b/Aiolos/Aiolos/Sources/Panel.swift
@@ -341,12 +341,17 @@ private extension Panel {
         self.panelView.configure(with: newConfiguration)
         self.resizeHandle.configure(with: newConfiguration)
         self.separatorView.configure(with: newConfiguration)
-        self.gestures.configure(with: newConfiguration)
 
         let modeChanged = oldConfiguration.mode != newConfiguration.mode
         let positionChanged = oldConfiguration.position != newConfiguration.position
         let marginsChanged = oldConfiguration.margins != newConfiguration.margins
         let positionLogicChanged = oldConfiguration.positionLogic != newConfiguration.positionLogic
+        let gestureResizingModeChanged = oldConfiguration.gestureResizingMode != newConfiguration.gestureResizingMode
+        let horizontalPositioningChanged = oldConfiguration.isHorizontalPositioningEnabled != newConfiguration.isHorizontalPositioningEnabled
+
+        if modeChanged || positionChanged || marginsChanged || positionLogicChanged || gestureResizingModeChanged || horizontalPositioningChanged {
+            self.gestures.configure(with: newConfiguration)
+        }
 
         if modeChanged || positionChanged {
             let size = self.size(for: newConfiguration.mode)

--- a/Aiolos/Aiolos/Sources/PanelGestures.swift
+++ b/Aiolos/Aiolos/Sources/PanelGestures.swift
@@ -44,7 +44,6 @@ final class PanelGestures: NSObject {
     }
 
     func configure(with configuration: Panel.Configuration) {
-        self.cancel()
         self.isVerticalPanEnabled = configuration.gestureResizingMode != .disabled
         self.isHorizontalPanEnabled = configuration.isHorizontalPositioningEnabled
     }


### PR DESCRIPTION
This allows us to change the appearance of the panel (e.g. shadow) without cancelling any gesture recognizers.