### PR TITLE
Improve PanelRepositionDelegate method naming

### DIFF
--- a/Aiolos/Aiolos/Sources/PanelAnimator.swift
+++ b/Aiolos/Aiolos/Sources/PanelAnimator.swift
@@ -100,7 +100,7 @@ final class PanelAnimator {
         guard let repositionDelegate = self.panel.repositionDelegate else { return false }
         guard self.panel.isVisible else { return false }
         
-        return repositionDelegate.panel(self.panel, shouldMoveTo: frame)
+        return repositionDelegate.panel(self.panel, willMoveTo: frame)
     }
     
     func notifyDelegateOfMove(to endFrame: CGRect, context: PanelRepositionContext) -> PanelRepositionContext.Instruction {

--- a/Aiolos/Aiolos/Sources/PanelDelegate.swift
+++ b/Aiolos/Aiolos/Sources/PanelDelegate.swift
@@ -34,8 +34,9 @@ public protocol PanelRepositionDelegate: AnyObject {
     /// Tells the delegate that the `panel` has started moving
     func panelDidStartMoving(_ panel: Panel)
 
-    /// Asks the delegate if the `panel` can move to a specific frame
-    func panel(_ panel: Panel, shouldMoveTo frame: CGRect) -> Bool
+    /// Tells the delegate that the `panel` will move to a specific frame
+    /// Returning false will result in a rubber-band effect
+    func panel(_ panel: Panel, willMoveTo frame: CGRect) -> Bool
 
     /// Tells the delegate that the `panel` did stop moving
     func panel(_ panel: Panel, didStopMoving endFrame: CGRect, with context: PanelRepositionContext) -> PanelRepositionContext.Instruction

--- a/Aiolos/Aiolos/Sources/PanelGestures.swift
+++ b/Aiolos/Aiolos/Sources/PanelGestures.swift
@@ -177,7 +177,8 @@ private extension PanelGestures {
             
             let translation = pan.translation(in: parentView)
             let transformation = CGAffineTransform(translationX: translation.x, y: 0.0)
-            let targetFrame = self.panel.view.frame.applying(transformation)
+            let originalFrame = self.panel.view.frame.applying(self.panel.view.transform.inverted())
+            let targetFrame = originalFrame.applying(transformation)
             let moveAllowed = self.panel.animator.askDelegateAboutMove(to: targetFrame)
             let xOffset = dragOffset(for: translation, moveAllowed: moveAllowed)
             guard xOffset != 0.0 else { return }

--- a/Aiolos/Demo/ViewController.swift
+++ b/Aiolos/Demo/ViewController.swift
@@ -130,10 +130,11 @@ extension ViewController: PanelRepositionDelegate {
         print("Panel did start moving")
     }
 
-    func panel(_ panel: Panel, shouldMoveTo frame: CGRect) -> Bool {
+    func panel(_ panel: Panel, willMoveTo frame: CGRect) -> Bool {
         print("Panel will move to frame \(frame)")
 
         // we can prevent the panel from begin dragged
+        // returning false will result in a rubber-band effect
         return true
     }
 


### PR DESCRIPTION

Rename PanelRepositionDelegate method to `panel(_, willMoveTo)` to indicate that performing side effects is.