### PR TITLE
Allow pointer scroll to resize/move panel

### DIFF
--- a/Aiolos/Aiolos/Sources/HorizontalPanGestureRecognizer.swift
+++ b/Aiolos/Aiolos/Sources/HorizontalPanGestureRecognizer.swift
@@ -5,4 +5,14 @@
 import UIKit
 
 /// UIPanGestureRecognizer that's being used for moving the panel horizontally
-public final class HorizontalPanGestureRecognizer: UIPanGestureRecognizer { }
+public final class HorizontalPanGestureRecognizer: UIPanGestureRecognizer {
+
+    public override init(target: Any?, action: Selector?) {
+        super.init(target: target, action: action)
+
+        if #available(iOS 13.4, *) {
+            // Allow HorizontalPanGestureRecognizer to detect horizontal pointer scrolls to move the panel
+            self.allowedScrollTypesMask = .all
+        }
+    }
+}

--- a/Aiolos/Aiolos/Sources/HorizontalPanGestureRecognizer.swift
+++ b/Aiolos/Aiolos/Sources/HorizontalPanGestureRecognizer.swift
@@ -7,12 +7,13 @@ import UIKit
 /// UIPanGestureRecognizer that's being used for moving the panel horizontally
 public final class HorizontalPanGestureRecognizer: UIPanGestureRecognizer {
 
-    public override init(target: Any?, action: Selector?) {
-        super.init(target: target, action: action)
+    // MARK: - Properties
 
-        if #available(iOS 13.4, *), NSClassFromString("UIPointerInteraction") != nil {
-            // Allow HorizontalPanGestureRecognizer to detect horizontal pointer scrolls to move the panel
-            self.allowedScrollTypesMask = .continuous
+    public var detectsPointerScrolling: Bool = false {
+        didSet {
+            guard #available(iOS 13.4, *), NSClassFromString("UIPointerInteraction") != nil else { return }
+
+            self.allowedScrollTypesMask = self.detectsPointerScrolling ? .continuous : []
         }
     }
 }

--- a/Aiolos/Aiolos/Sources/HorizontalPanGestureRecognizer.swift
+++ b/Aiolos/Aiolos/Sources/HorizontalPanGestureRecognizer.swift
@@ -10,7 +10,7 @@ public final class HorizontalPanGestureRecognizer: UIPanGestureRecognizer {
     public override init(target: Any?, action: Selector?) {
         super.init(target: target, action: action)
 
-        if #available(iOS 13.4, *) {
+        if #available(iOS 13.4, *), NSClassFromString("UIPointerInteraction") != nil {
             // Allow HorizontalPanGestureRecognizer to detect horizontal pointer scrolls to move the panel
             self.allowedScrollTypesMask = .all
         }

--- a/Aiolos/Aiolos/Sources/HorizontalPanGestureRecognizer.swift
+++ b/Aiolos/Aiolos/Sources/HorizontalPanGestureRecognizer.swift
@@ -12,7 +12,7 @@ public final class HorizontalPanGestureRecognizer: UIPanGestureRecognizer {
 
         if #available(iOS 13.4, *), NSClassFromString("UIPointerInteraction") != nil {
             // Allow HorizontalPanGestureRecognizer to detect horizontal pointer scrolls to move the panel
-            self.allowedScrollTypesMask = .all
+            self.allowedScrollTypesMask = .continuous
         }
     }
 }

--- a/Aiolos/Aiolos/Sources/PanGestureRecognizer.swift
+++ b/Aiolos/Aiolos/Sources/PanGestureRecognizer.swift
@@ -33,12 +33,9 @@ public final class PointerScrollGestureRecognizer: UIPanGestureRecognizer {
 
     // MARK: - Lifecycle
 
-    public override init(target: Any?, action: Selector?) {
+    /// As a non-failable initializer cannot be overrididden by failable initializer, we mark this initializer as 'private' and use make() fatory method from outside
+    private override init(target: Any?, action: Selector?) {
         super.init(target: target, action: action)
-
-        if #available(iOS 13.4, *), NSClassFromString("UIPointerInteraction") != nil {
-            self.allowedScrollTypesMask = .continuous
-        }
     }
 }
 
@@ -47,7 +44,9 @@ public extension PointerScrollGestureRecognizer {
     static func make(withTarget target: Any?, action: Selector?) -> PointerScrollGestureRecognizer? {
         guard #available(iOS 13.4, *), NSClassFromString("UIPointerInteraction") != nil else { return nil }
 
-        return .init(target: target, action: action)
+        let gesture = PointerScrollGestureRecognizer(target: target, action: action)
+        gesture.allowedScrollTypesMask = .continuous
+        return gesture
     }
 }
 

--- a/Aiolos/Aiolos/Sources/PanGestureRecognizer.swift
+++ b/Aiolos/Aiolos/Sources/PanGestureRecognizer.swift
@@ -38,20 +38,17 @@ public final class PointerScrollGestureRecognizer: UIPanGestureRecognizer, PanGe
     public override init(target: Any?, action: Selector?) {
         super.init(target: nil, action: nil)
 
-        // Make sure 'self.didScroll' method is called before 'target.action'
+        // Make sure 'self.handleScroll' method is called before 'target.action'
         self.addTarget(self, action: #selector(handleScroll))
         if let target = target, let action = action {
             self.addTarget(target, action: action)
         }
 
-        self.minimumNumberOfTouches = 0
-        self.maximumNumberOfTouches = 0
-
         if #available(iOS 13.4, *), NSClassFromString("UIPointerInteraction") != nil {
             self.allowedScrollTypesMask = .continuous
         }
 
-        // Workaround for method touchesBegan not being called on pointer scrolls (iPadOS 13.5)
+        // Workaround for methods touches(Began|Moved|Ended) not being called on pointer scrolls (iPadOS 13.5)
         self.stateObservation = self.observe(\.state) { recognizer, change in
             switch recognizer.state {
             case .began:
@@ -60,7 +57,7 @@ public final class PointerScrollGestureRecognizer: UIPanGestureRecognizer, PanGe
                 self.currentPoint = location
                 self.didPan = false
             case .changed:
-                // handled by `didScroll` below
+                // handled by `handleScroll` below
                 break
             default:
                 break

--- a/Aiolos/Aiolos/Sources/PanGestureRecognizer.swift
+++ b/Aiolos/Aiolos/Sources/PanGestureRecognizer.swift
@@ -10,59 +10,44 @@ import Foundation
 import UIKit
 
 
-protocol PanGestureRecognizerProtocol: AnyObject {
-    var didPan: Bool { get }
-    var startMode: PanGestureRecognizer.StartMode { get set }
+/// Set of methods implemented by both UIPanGestureRecognizer and our own NoDelayPanGestureRecognizer
+@objc
+protocol PanGestureRecognizer: AnyObject {
 
+    @objc(translationInView:)
     func translation(in view: UIView?) -> CGPoint
+    @objc(setTranslation:inView:)
     func setTranslation(_ translation: CGPoint, in view: UIView?)
+    @objc(velocityInView:)
     func velocity(in view: UIView?) -> CGPoint
 }
 
+extension UIPanGestureRecognizer: PanGestureRecognizer { }
 
-/// GestureRecognizer that recognizes only pointer scroll gestures
-public final class PointerScrollGestureRecognizer: UIPanGestureRecognizer, PanGestureRecognizerProtocol {
 
-    private var stateObservation: NSKeyValueObservation?
+// MARK: - PointerScrollGestureRecognizer
 
-    // MARK: Properties
-
-    private var initialPoint: CGPoint?
-    private var currentPoint: CGPoint?
-
-    private(set) var didPan: Bool = false
-    var startMode: PanGestureRecognizer.StartMode = .onFixedArea
+/// A UIPanGestureRecognizer subclass that recognizes only pointer scroll gestures
+/// We won't need this after UIGestureRecognizer subclasses will be able to detect pointer scrolls (FB7733482)
+public final class PointerScrollGestureRecognizer: UIPanGestureRecognizer {
 
     // MARK: - Lifecycle
 
     public override init(target: Any?, action: Selector?) {
-        super.init(target: nil, action: nil)
-
-        // Make sure 'self.handleScroll' method is called before 'target.action'
-        self.addTarget(self, action: #selector(handleScroll))
-        if let target = target, let action = action {
-            self.addTarget(target, action: action)
-        }
+        super.init(target: target, action: action)
 
         if #available(iOS 13.4, *), NSClassFromString("UIPointerInteraction") != nil {
             self.allowedScrollTypesMask = .continuous
         }
+    }
+}
 
-        // Workaround for methods touches(Began|Moved|Ended) not being called on pointer scrolls (iPadOS 13.5)
-        self.stateObservation = self.observe(\.state) { recognizer, change in
-            switch recognizer.state {
-            case .began:
-                let location = self.location(in: self.view?.window)
-                self.initialPoint = location
-                self.currentPoint = location
-                self.didPan = false
-            case .changed:
-                // handled by `handleScroll` below
-                break
-            default:
-                break
-            }
-        }
+public extension PointerScrollGestureRecognizer {
+
+    static func make(withTarget target: Any?, action: Selector?) -> PointerScrollGestureRecognizer? {
+        guard #available(iOS 13.4, *), NSClassFromString("UIPointerInteraction") != nil else { return nil }
+
+        return .init(target: target, action: action)
     }
 }
 
@@ -76,88 +61,22 @@ public extension PointerScrollGestureRecognizer {
 
         return super.shouldReceive(event)
     }
-
-    override func reset() {
-        super.reset()
-
-        self.didPan = false
-        self.startMode = .onFixedArea
-    }
-
-    override func location(in view: UIView?) -> CGPoint {
-        let location = super.location(in: view)
-
-        // I found the location reported is a bit off, causing it to
-        // trigger both scroll view scrolling and panel resizing (iPadOS 13.5)
-        return CGPoint(x: location.x, y: location.y + 20.0)
-    }
-}
-
-// MARK: - Private
-
-private extension PointerScrollGestureRecognizer {
-
-    struct Constants {
-        static let minTranslation: CGFloat = 5.0
-    }
-
-    var totalTranslation: CGPoint {
-        guard let view = self.view else { return .zero }
-        guard let initialPoint = self.initialPoint else { return .zero }
-        guard let currentPoint = self.currentPoint else { return .zero }
-
-        return self.translation(from: initialPoint, to: currentPoint, in: view)
-    }
-
-    func translation(from startPoint: CGPoint, to endPoint: CGPoint, in view: UIView) -> CGPoint {
-        guard let window = self.view?.window else { return .zero }
-
-        let startPointInView = window.convert(startPoint, to: view)
-        let endPointInView = window.convert(endPoint, to: view)
-
-        return CGPoint(x: endPointInView.x - startPointInView.x, y: endPointInView.y - startPointInView.y)
-    }
-
-    @objc
-    private func handleScroll(_ sender: UIPanGestureRecognizer) {
-        let location = self.location(in: self.view?.window)
-        self.currentPoint = location
-
-        if self.totalTranslation.hypotenuse() > Constants.minTranslation && self.didPan == false {
-            self.didPan = true
-
-            // if we recognized a pan, make sure it can be considered a vertical pan
-            guard self.totalTranslation.direction() == .vertical else {
-                self.state = .cancelled
-                return
-            }
-        }
-    }
 }
 
 
-/// GestureRecognizer that recognizes a pan gesture without any delay
-public final class PanGestureRecognizer: UIGestureRecognizer, PanGestureRecognizerProtocol {
+// MARK: - NoDelayPanGestureRecognizer
 
-    enum StartMode: Equatable {
-        case onFixedArea
-        case onVerticallyScrollableArea(competingScrollView: UIScrollView)
-    }
+/// A UIGestureRecognizer subclass that recognizes pan gestures without any delay but doesn't recognize scrolling with pointer
+public final class NoDelayPanGestureRecognizer: UIGestureRecognizer {
 
     private lazy var panForVelocity: UIPanGestureRecognizer = self.makeVelocityPan()
-    private var initialPoint: CGPoint?
     private var lastPoint: CGPoint?
     private var currentPoint: CGPoint?
-
-    // MARK: Properties
-
-    private(set) var didPan: Bool = false
-    var startMode: StartMode = .onFixedArea
 }
 
 // MARK: - UIGestureRecognizer+Subclass
 
-public extension PanGestureRecognizer {
+public extension NoDelayPanGestureRecognizer {
 
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent) {
         super.touchesBegan(touches, with: event)
@@ -177,11 +96,9 @@ public extension PanGestureRecognizer {
         guard let touch = touches.first else { return }
 
         let location = touch.location(in: self.view?.window)
-        self.initialPoint = location
         self.lastPoint = location
         self.currentPoint = location
         self.state = .began
-        self.didPan = false
     }
 
     override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent) {
@@ -192,17 +109,6 @@ public extension PanGestureRecognizer {
 
         let currentPoint = touch.location(in: self.view?.window)
         self.currentPoint = currentPoint
-
-        if self.totalTranslation.hypotenuse() > Constants.minTranslation && self.didPan == false {
-            self.didPan = true
-
-            // if we recognized a pan, make sure it can be considered a vertical pan
-            guard self.totalTranslation.direction() == .vertical else {
-                self.state = .cancelled
-                return
-            }
-        }
-
         self.state = .changed
     }
 
@@ -223,19 +129,18 @@ public extension PanGestureRecognizer {
     override func reset() {
         super.reset()
 
-        self.didPan = false
-        self.startMode = .onFixedArea
         self.panForVelocity = self.makeVelocityPan()
     }
 }
 
 // MARK: - PanGestureRecognizer
 
-extension PanGestureRecognizer {
+extension NoDelayPanGestureRecognizer: PanGestureRecognizer {
 
     func translation(in view: UIView?) -> CGPoint {
         guard let lastPoint = self.lastPoint else { return .zero }
         guard let currentPoint = self.currentPoint else { return .zero }
+        guard let view = view ?? self.view?.window else { return .zero }
 
         return self.translation(from: lastPoint, to: currentPoint, in: view)
     }
@@ -253,11 +158,7 @@ extension PanGestureRecognizer {
 
 // MARK: - Private
 
-private extension PanGestureRecognizer {
-
-    struct Constants {
-        static let minTranslation: CGFloat = 5.0
-    }
+private extension NoDelayPanGestureRecognizer {
 
     func makeVelocityPan() -> UIPanGestureRecognizer {
         let pan = UIPanGestureRecognizer(target: nil, action: nil)
@@ -267,39 +168,12 @@ private extension PanGestureRecognizer {
         return pan
     }
 
-    var totalTranslation: CGPoint {
-        guard let view = self.view else { return .zero }
-        guard let initialPoint = self.initialPoint else { return .zero }
-        guard let currentPoint = self.currentPoint else { return .zero }
-
-        return self.translation(from: initialPoint, to: currentPoint, in: view)
-    }
-
-    func translation(from startPoint: CGPoint, to endPoint: CGPoint, in view: UIView?) -> CGPoint {
-        guard let window = self.view?.window else { return .zero }
+    func translation(from startPoint: CGPoint, to endPoint: CGPoint, in view: UIView) -> CGPoint {
+        guard let window = view.window else { return .zero }
 
         let startPointInView = window.convert(startPoint, to: view)
         let endPointInView = window.convert(endPoint, to: view)
 
         return CGPoint(x: endPointInView.x - startPointInView.x, y: endPointInView.y - startPointInView.y)
-    }
-}
-
-private extension CGPoint {
-
-    enum Direction {
-        case horizontal
-        case vertical
-    }
-
-    func hypotenuse() -> CGFloat {
-        return sqrt(self.x * self.x + self.y * self.y)
-    }
-
-    func direction() -> Direction {
-        let horizontalDiff = self.x * self.x
-        let verticalDiff = self.y * self.y
-
-        return horizontalDiff > verticalDiff ? .horizontal : .vertical
     }
 }

--- a/Aiolos/Aiolos/Sources/PanGestureRecognizer.swift
+++ b/Aiolos/Aiolos/Sources/PanGestureRecognizer.swift
@@ -47,7 +47,7 @@ public final class PointerScrollGestureRecognizer: UIPanGestureRecognizer, PanGe
         self.minimumNumberOfTouches = 0
         self.maximumNumberOfTouches = 0
 
-        if #available(iOS 13.4, *) {
+        if #available(iOS 13.4, *), NSClassFromString("UIPointerInteraction") != nil {
             self.allowedScrollTypesMask = .all
         }
 

--- a/Aiolos/Aiolos/Sources/PanGestureRecognizer.swift
+++ b/Aiolos/Aiolos/Sources/PanGestureRecognizer.swift
@@ -32,7 +32,7 @@ public final class PointerScrollGestureRecognizer: UIPanGestureRecognizer {
 
     // MARK: - Lifecycle
 
-    /// As a non-failable initializer cannot be overrididden by failable initializer, we mark this initializer as 'private' and use make() fatory method from outside
+    /// As a non-failable initializer cannot be overwritten by a failable initializer, we mark this initializer as 'private' and use make() factory method from outside
     private override init(target: Any?, action: Selector?) {
         super.init(target: target, action: action)
     }

--- a/Aiolos/Aiolos/Sources/PanGestureRecognizer.swift
+++ b/Aiolos/Aiolos/Sources/PanGestureRecognizer.swift
@@ -38,8 +38,8 @@ public final class PointerScrollGestureRecognizer: UIPanGestureRecognizer, PanGe
     public override init(target: Any?, action: Selector?) {
         super.init(target: nil, action: nil)
 
-        // Workaround for method touchesMoved not being called on pointer scrolls (iPadOS 13.5)
-        self.addTarget(self, action: #selector(didScroll))
+        // Make sure 'self.didScroll' method is called before 'target.action'
+        self.addTarget(self, action: #selector(handleScroll))
         if let target = target, let action = action {
             self.addTarget(target, action: action)
         }
@@ -53,7 +53,6 @@ public final class PointerScrollGestureRecognizer: UIPanGestureRecognizer, PanGe
 
         // Workaround for method touchesBegan not being called on pointer scrolls (iPadOS 13.5)
         self.stateObservation = self.observe(\.state) { recognizer, change in
-
             switch recognizer.state {
             case .began:
                 let location = self.location(in: self.view?.window)
@@ -115,15 +114,9 @@ private extension PointerScrollGestureRecognizer {
     }
 
     @objc
-    private func didScroll(_ sender: UIPanGestureRecognizer) {
+    private func handleScroll(_ sender: UIPanGestureRecognizer) {
         let location = self.location(in: self.view?.window)
         self.currentPoint = location
-
-        print("changed")
-        print("location", self.location(in: self.view?.window))
-        print("velocity", self.velocity(in: self.view?.window))
-        print("translation", self.translation(in: self.view?.window))
-        print("totalTranslation", self.totalTranslation)
 
         if self.totalTranslation.hypotenuse() > Constants.minTranslation && self.didPan == false {
             self.didPan = true

--- a/Aiolos/Aiolos/Sources/PanGestureRecognizer.swift
+++ b/Aiolos/Aiolos/Sources/PanGestureRecognizer.swift
@@ -86,6 +86,14 @@ public extension PointerScrollGestureRecognizer {
         self.didPan = false
         self.startMode = .onFixedArea
     }
+
+    override func location(in view: UIView?) -> CGPoint {
+        let location = super.location(in: view)
+
+        // I found the location reported is a bit off, causing it to
+        // trigger both scroll view scrolling and panel resizing (iPadOS 13.5)
+        return CGPoint(x: location.x, y: location.y + 20.0)
+    }
 }
 
 // MARK: - Private

--- a/Aiolos/Aiolos/Sources/PanGestureRecognizer.swift
+++ b/Aiolos/Aiolos/Sources/PanGestureRecognizer.swift
@@ -48,7 +48,7 @@ public final class PointerScrollGestureRecognizer: UIPanGestureRecognizer, PanGe
         self.maximumNumberOfTouches = 0
 
         if #available(iOS 13.4, *), NSClassFromString("UIPointerInteraction") != nil {
-            self.allowedScrollTypesMask = .all
+            self.allowedScrollTypesMask = .continuous
         }
 
         // Workaround for method touchesBegan not being called on pointer scrolls (iPadOS 13.5)

--- a/Aiolos/Aiolos/Sources/PanGestureRecognizer.swift
+++ b/Aiolos/Aiolos/Sources/PanGestureRecognizer.swift
@@ -13,6 +13,8 @@ import UIKit
 @objc
 protocol PanGestureRecognizer: AnyObject {
 
+    // We need the @objc annotations because of `typealias PanOrScrollGestureRecognizer = UIGestureRecognizer & PanGestureRecognizer` in PanelGestures
+    // which makes the methods in our `NoDelayPanGestureRecognizer` to be called via objc bridging. If we don't have these annotations, we get crashes in runtime.
     @objc(translationInView:)
     func translation(in view: UIView?) -> CGPoint
     @objc(setTranslation:inView:)

--- a/Aiolos/Aiolos/Sources/Panel.swift
+++ b/Aiolos/Aiolos/Sources/Panel.swift
@@ -394,9 +394,10 @@ private extension Panel {
         let marginsChanged = oldConfiguration.margins != newConfiguration.margins
         let positionLogicChanged = oldConfiguration.positionLogic != newConfiguration.positionLogic
         let gestureResizingModeChanged = oldConfiguration.gestureResizingMode != newConfiguration.gestureResizingMode
+        let pointerScrollGesturesChanged = oldConfiguration.pointerScrollGestures != newConfiguration.pointerScrollGestures
         let horizontalPositioningChanged = oldConfiguration.isHorizontalPositioningEnabled != newConfiguration.isHorizontalPositioningEnabled
 
-        if modeChanged || positionChanged || marginsChanged || positionLogicChanged || gestureResizingModeChanged || horizontalPositioningChanged {
+        if modeChanged || positionChanged || marginsChanged || positionLogicChanged || gestureResizingModeChanged || pointerScrollGesturesChanged || horizontalPositioningChanged {
             self.gestures.cancel()
         }
 

--- a/Aiolos/Aiolos/Sources/Panel.swift
+++ b/Aiolos/Aiolos/Sources/Panel.swift
@@ -394,10 +394,9 @@ private extension Panel {
         let marginsChanged = oldConfiguration.margins != newConfiguration.margins
         let positionLogicChanged = oldConfiguration.positionLogic != newConfiguration.positionLogic
         let gestureResizingModeChanged = oldConfiguration.gestureResizingMode != newConfiguration.gestureResizingMode
-        let pointerScrollGesturesChanged = oldConfiguration.pointerScrollGestures != newConfiguration.pointerScrollGestures
         let horizontalPositioningChanged = oldConfiguration.isHorizontalPositioningEnabled != newConfiguration.isHorizontalPositioningEnabled
 
-        if modeChanged || positionChanged || marginsChanged || positionLogicChanged || gestureResizingModeChanged || pointerScrollGesturesChanged || horizontalPositioningChanged {
+        if modeChanged || positionChanged || marginsChanged || positionLogicChanged || gestureResizingModeChanged || horizontalPositioningChanged {
             self.gestures.cancel()
         }
 

--- a/Aiolos/Aiolos/Sources/PanelConfiguration.swift
+++ b/Aiolos/Aiolos/Sources/PanelConfiguration.swift
@@ -18,6 +18,7 @@ public extension Panel {
         public typealias Position = _PanelPosition
         public typealias PositionLogic = _PanelPositionLogic
         public typealias GestureResizingMode = _PanelGestureResizingMode
+        public typealias PointerScrollGestures = _PointerScrollGestures
 
         public enum ResizeHandleMode {
             case hidden
@@ -44,6 +45,7 @@ public extension Panel {
         public var mode: Mode
         public var supportedModes: Set<Mode>
         public var gestureResizingMode: GestureResizingMode
+        public var pointerScrollGestures: PointerScrollGestures
         public var appearance: Appearance
         public var isHorizontalPositioningEnabled: Bool
     }
@@ -70,6 +72,7 @@ public extension Panel.Configuration {
                                    mode: .compact,
                                    supportedModes: [.compact, .expanded, .fullHeight],
                                    gestureResizingMode: .includingContent,
+                                   pointerScrollGestures: [.position, .resize],
                                    appearance: appearance,
                                    isHorizontalPositioningEnabled: false)
     }
@@ -161,6 +164,17 @@ public enum _PanelGestureResizingMode: Int {
     case disabled
     case excludingContent
     case includingContent
+}
+
+public struct _PointerScrollGestures: OptionSet {
+    public let rawValue: Int
+
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+
+    public static let resize = _PointerScrollGestures(rawValue: 1 << 0)
+    public static let position = _PointerScrollGestures(rawValue: 1 << 1)
 }
 
 extension _PanelPositionLogic {

--- a/Aiolos/Aiolos/Sources/PanelConfiguration.swift
+++ b/Aiolos/Aiolos/Sources/PanelConfiguration.swift
@@ -17,7 +17,19 @@ public extension Panel {
         public typealias Edge = _PanelEdge
         public typealias Position = _PanelPosition
         public typealias PositionLogic = _PanelPositionLogic
-        public typealias GestureResizingMode = _PanelGestureResizingMode
+
+        public struct GestureResizingMode: OptionSet {
+            public let rawValue: Int
+
+            public init(rawValue: Int) {
+                self.rawValue = rawValue
+            }
+
+            public static let handle = GestureResizingMode(rawValue: 1 << 0)
+            public static let content = GestureResizingMode(rawValue: 1 << 1)
+            public static let byTouch = GestureResizingMode(rawValue: 1 << 2)
+            public static let byPointerScroll = GestureResizingMode(rawValue: 1 << 3)
+        }
 
         public enum ResizeHandleMode {
             case hidden
@@ -69,7 +81,7 @@ public extension Panel.Configuration {
                                    margins: NSDirectionalEdgeInsets(top: 10.0, leading: 10.0, bottom: 0.0, trailing: 10.0),
                                    mode: .compact,
                                    supportedModes: [.compact, .expanded, .fullHeight],
-                                   gestureResizingMode: [.handle, .content, .byTouch, .byPointerScroll],
+                                   gestureResizingMode: .includingContent,
                                    appearance: appearance,
                                    isHorizontalPositioningEnabled: false)
     }
@@ -156,25 +168,6 @@ public enum _PanelPositionLogic: Int {
     }
 }
 
-public struct _PanelGestureResizingMode: OptionSet {
-    public let rawValue: Int
-
-    public init(rawValue: Int) {
-        self.rawValue = rawValue
-    }
-
-    public static let handle = _PanelGestureResizingMode(rawValue: 1 << 0)
-    public static let content = _PanelGestureResizingMode(rawValue: 1 << 1)
-    public static let byTouch = _PanelGestureResizingMode(rawValue: 1 << 2)
-    public static let byPointerScroll = _PanelGestureResizingMode(rawValue: 1 << 3)
-}
-
-extension _PanelGestureResizingMode {
-
-    var isPanningByTouchEnabled: Bool { self.contains(.byTouch) && (self.contains(.content) || self.contains(.handle)) }
-    var isScrollingByPointerEnabled: Bool { self.contains(.byPointerScroll) && (self.contains(.content) || self.contains(.handle)) }
-}
-
 extension _PanelPositionLogic {
 
     func applyingInsets(of view: UIView, to insets: NSDirectionalEdgeInsets, edge: Panel.Configuration.Edge) -> NSDirectionalEdgeInsets {
@@ -196,4 +189,12 @@ extension _PanelPositionLogic {
 
         return insets
     }
+}
+
+extension Panel.Configuration.GestureResizingMode {
+
+    public static let includingContent: Self = [.handle, .content, .byTouch, .byPointerScroll]
+    public static let excludingContent: Self = [.handle, .byTouch, .byPointerScroll]
+    var isPanningByTouchEnabled: Bool { self.contains(.byTouch) && (self.contains(.content) || self.contains(.handle)) }
+    var isScrollingByPointerEnabled: Bool { self.contains(.byPointerScroll) && (self.contains(.content) || self.contains(.handle)) }
 }

--- a/Aiolos/Aiolos/Sources/PanelConfiguration.swift
+++ b/Aiolos/Aiolos/Sources/PanelConfiguration.swift
@@ -18,7 +18,6 @@ public extension Panel {
         public typealias Position = _PanelPosition
         public typealias PositionLogic = _PanelPositionLogic
         public typealias GestureResizingMode = _PanelGestureResizingMode
-        public typealias PointerScrollGestures = _PointerScrollGestures
 
         public enum ResizeHandleMode {
             case hidden
@@ -45,7 +44,6 @@ public extension Panel {
         public var mode: Mode
         public var supportedModes: Set<Mode>
         public var gestureResizingMode: GestureResizingMode
-        public var pointerScrollGestures: PointerScrollGestures
         public var appearance: Appearance
         public var isHorizontalPositioningEnabled: Bool
     }
@@ -71,8 +69,7 @@ public extension Panel.Configuration {
                                    margins: NSDirectionalEdgeInsets(top: 10.0, leading: 10.0, bottom: 0.0, trailing: 10.0),
                                    mode: .compact,
                                    supportedModes: [.compact, .expanded, .fullHeight],
-                                   gestureResizingMode: .includingContent,
-                                   pointerScrollGestures: [.position, .resize],
+                                   gestureResizingMode: [.handle, .content, .byTouch, .byPointerScroll],
                                    appearance: appearance,
                                    isHorizontalPositioningEnabled: false)
     }
@@ -159,22 +156,23 @@ public enum _PanelPositionLogic: Int {
     }
 }
 
-@objc(PanelGestureResizingMode)
-public enum _PanelGestureResizingMode: Int {
-    case disabled
-    case excludingContent
-    case includingContent
-}
-
-public struct _PointerScrollGestures: OptionSet {
+public struct _PanelGestureResizingMode: OptionSet {
     public let rawValue: Int
 
     public init(rawValue: Int) {
         self.rawValue = rawValue
     }
 
-    public static let resize = _PointerScrollGestures(rawValue: 1 << 0)
-    public static let position = _PointerScrollGestures(rawValue: 1 << 1)
+    public static let handle = _PanelGestureResizingMode(rawValue: 1 << 0)
+    public static let content = _PanelGestureResizingMode(rawValue: 1 << 1)
+    public static let byTouch = _PanelGestureResizingMode(rawValue: 1 << 2)
+    public static let byPointerScroll = _PanelGestureResizingMode(rawValue: 1 << 3)
+}
+
+extension _PanelGestureResizingMode {
+
+    var isPanningByTouchEnabled: Bool { self.contains(.byTouch) && (self.contains(.content) || self.contains(.handle)) }
+    var isScrollingByPointerEnabled: Bool { self.contains(.byPointerScroll) && (self.contains(.content) || self.contains(.handle)) }
 }
 
 extension _PanelPositionLogic {

--- a/Aiolos/Aiolos/Sources/PanelGestures.swift
+++ b/Aiolos/Aiolos/Sources/PanelGestures.swift
@@ -26,6 +26,11 @@ final class PanelGestures: NSObject {
         set { self.horizontalPan.isEnabled = newValue }
     }
 
+    private var isHorizontalPointerScrolEnabled: Bool {
+        get { return self.horizontalPan.detectsPointerScrolling }
+        set { self.horizontalPan.detectsPointerScrolling = newValue }
+    }
+
     private var isVerticalPointerScrollEnabled: Bool {
         get { return self.verticalPointerScroll.isEnabled }
         set { self.verticalPointerScroll.isEnabled = newValue }
@@ -53,8 +58,9 @@ final class PanelGestures: NSObject {
 
     func configure(with configuration: Panel.Configuration) {
         self.isHorizontalPanEnabled = configuration.isHorizontalPositioningEnabled
-        self.isVerticalPointerScrollEnabled = configuration.gestureResizingMode != .disabled // TODO: add a dedicated config option for pointer scroll
+        self.isHorizontalPointerScrolEnabled = configuration.pointerScrollGestures.contains(.position)
         self.isVerticalPanEnabled = configuration.gestureResizingMode != .disabled
+        self.isVerticalPointerScrollEnabled = self.isVerticalPanEnabled && configuration.pointerScrollGestures.contains(.resize)
     }
 
     func cancel() {

--- a/Aiolos/Aiolos/Sources/PanelGestures.swift
+++ b/Aiolos/Aiolos/Sources/PanelGestures.swift
@@ -507,9 +507,7 @@ private extension PanelGestures {
             pan.setTranslation(.zero, in: self.panel.view)
 
             // However, didPan still works with totalTranslation under the covers
-            guard state.didPan else { return }
-
-            if pan.cancelsTouchesInView == false {
+            if state.didPan && pan.cancelsTouchesInView == false {
                 guard self.handlePanDragStart(pan, state: state) else { return }
             }
 

--- a/Aiolos/Aiolos/Sources/PanelGestures.swift
+++ b/Aiolos/Aiolos/Sources/PanelGestures.swift
@@ -740,6 +740,7 @@ private extension PanelGestures {
         return enclosingScrollView.isScrolledToTop
     }
 
+    // TODO: Do better hitTesting so that the panel won't resize together with scroll view  when pointer is placed between nav bar and table view
     func verticallyScrollableView(of contentViewController: UIViewController, interactingWith gestureRecognizer: UIGestureRecognizer) -> UIScrollView? {
         let location = gestureRecognizer.location(in: contentViewController.view)
         guard let hitView = contentViewController.view.hitTest(location, with: nil) else { return nil }

--- a/Aiolos/Aiolos/Sources/PanelGestures.swift
+++ b/Aiolos/Aiolos/Sources/PanelGestures.swift
@@ -24,22 +24,22 @@ final class PanelGestures: NSObject {
     private lazy var verticalHandler: VerticalHandler = .init(gestures: self)
 
     private var isHorizontalPanEnabled: Bool {
-        get { return self.horizontalPan.isEnabled }
+        get { self.horizontalPan.isEnabled }
         set { self.horizontalPan.isEnabled = newValue }
     }
 
     private var isHorizontalPointerScrolEnabled: Bool {
-        get { return self.horizontalPan.detectsPointerScrolling }
+        get { self.horizontalPan.detectsPointerScrolling }
         set { self.horizontalPan.detectsPointerScrolling = newValue }
     }
 
     private var isVerticalPointerScrollEnabled: Bool {
-        get { return self.verticalPointerScroll.isEnabled }
+        get { self.verticalPointerScroll.isEnabled }
         set { self.verticalPointerScroll.isEnabled = newValue }
     }
 
     private var isVerticalPanEnabled: Bool {
-        get { return self.verticalPan.isEnabled }
+        get { self.verticalPan.isEnabled }
         set { self.verticalPan.isEnabled = newValue }
     }
 

--- a/Aiolos/Aiolos/Sources/PanelGestures.swift
+++ b/Aiolos/Aiolos/Sources/PanelGestures.swift
@@ -28,11 +28,6 @@ final class PanelGestures: NSObject {
         set { self.horizontalPan.isEnabled = newValue }
     }
 
-    private var isHorizontalPointerScrolEnabled: Bool {
-        get { self.horizontalPan.detectsPointerScrolling }
-        set { self.horizontalPan.detectsPointerScrolling = newValue }
-    }
-
     private var isVerticalPointerScrollEnabled: Bool {
         get { self.verticalPointerScroll?.isEnabled ?? false }
         set { self.verticalPointerScroll?.isEnabled = newValue }
@@ -62,7 +57,6 @@ final class PanelGestures: NSObject {
 
     func configure(with configuration: Panel.Configuration) {
         self.isHorizontalPanEnabled = configuration.isHorizontalPositioningEnabled
-        self.isHorizontalPointerScrolEnabled = configuration.isHorizontalPositioningEnabled // TODO: Do we want to enable this separatelly? If not, remove 'isHorizontalPointerScrolEnabled'
         self.isVerticalPanEnabled = configuration.gestureResizingMode.isPanningByTouchEnabled
         self.isVerticalPointerScrollEnabled = configuration.gestureResizingMode.isScrollingByPointerEnabled
     }
@@ -689,6 +683,7 @@ private extension PanelGestures {
         let pan = HorizontalPanGestureRecognizer(target: self.horizontalHandler, action: #selector(HorizontalHandler.handlePan))
         pan.delegate = self
         pan.cancelsTouchesInView = true
+        pan.detectsPointerScrolling = true
         return pan
     }
 
@@ -746,7 +741,6 @@ private extension PanelGestures {
         return enclosingScrollView.isScrolledToTop
     }
 
-    // TODO: Do better hitTesting so that the panel won't resize together with scroll view  when pointer is placed between nav bar and table view
     func verticallyScrollableView(of contentViewController: UIViewController, interactingWith gestureRecognizer: UIGestureRecognizer) -> UIScrollView? {
         let location = gestureRecognizer.location(in: contentViewController.view)
         guard let hitView = contentViewController.view.hitTest(location, with: nil) else { return nil }

--- a/Aiolos/Aiolos/Sources/PanelGestures.swift
+++ b/Aiolos/Aiolos/Sources/PanelGestures.swift
@@ -20,7 +20,7 @@ final class PanelGestures: NSObject {
     private lazy var verticalPan: NoDelayPanGestureRecognizer = self.makeVerticalPanGestureRecognizer()
     private lazy var verticalPanState: VerticalGestureState = .init(handler: self.verticalHandler)
     private lazy var verticalPointerScroll: PointerScrollGestureRecognizer? = self.makeVerticalPointerScrollGestureRecognizer()
-    private lazy var verticalGestureState: VerticalGestureState = .init(handler: self.verticalHandler)
+    private lazy var verticalPointerScrollState: VerticalGestureState = .init(handler: self.verticalHandler)
     private lazy var verticalHandler: VerticalHandler = .init(gestures: self)
 
     private var isHorizontalPanEnabled: Bool {
@@ -688,7 +688,7 @@ private extension PanelGestures {
     }
 
     func makeVerticalPointerScrollGestureRecognizer() -> PointerScrollGestureRecognizer? {
-        let gesture = PointerScrollGestureRecognizer.make(withTarget: self.verticalGestureState, action: #selector(VerticalGestureState.handlePan))
+        let gesture = PointerScrollGestureRecognizer.make(withTarget: self.verticalPointerScrollState, action: #selector(VerticalGestureState.handlePan))
         gesture?.delegate = self
         gesture?.cancelsTouchesInView = false
         return gesture

--- a/Aiolos/Aiolos/Sources/PanelGestures.swift
+++ b/Aiolos/Aiolos/Sources/PanelGestures.swift
@@ -16,10 +16,12 @@ final class PanelGestures: NSObject {
     private unowned let panel: Panel
 
     private lazy var horizontalPan: HorizontalPanGestureRecognizer = self.makeHorizontalPanGestureRecognizer()
+    private lazy var horizontalHandler: HorizontalHandler = .init(gestures: self)
+    private lazy var verticalPan: NoDelayPanGestureRecognizer = self.makeVerticalPanGestureRecognizer()
+    private lazy var verticalPanState: VerticalGestureState = .init(handler: self.verticalHandler)
     private lazy var verticalPointerScroll: PointerScrollGestureRecognizer = self.makeVerticalPointerScrollGestureRecognizer()
-    private lazy var verticalPan: PanGestureRecognizer = self.makeVerticalPanGestureRecognizer()
-    private lazy var horizontalHandler: HorizontalHandler = HorizontalHandler(gestures: self)
-    private lazy var verticalHandler: VerticalHandler = VerticalHandler(gestures: self)
+    private lazy var verticalPointerScrollState: VerticalGestureState = .init(handler: self.verticalHandler)
+    private lazy var verticalHandler: VerticalHandler = .init(gestures: self)
 
     private var isHorizontalPanEnabled: Bool {
         get { return self.horizontalPan.isEnabled }
@@ -312,7 +314,97 @@ private extension PanelGestures {
     }
 }
 
+
 private extension PanelGestures {
+
+    typealias PanOrScrollGestureRecognizer = UIGestureRecognizer & PanGestureRecognizer
+
+    enum StartMode: Equatable {
+        case onFixedArea
+        case onVerticallyScrollableArea(competingScrollView: UIScrollView)
+    }
+
+    struct Constants {
+        static let minTranslation: CGFloat = 5.0
+    }
+
+    // MARK: - VerticalGestureState
+
+    /// Handles QuickPanGestureRecognizer and PointerScrollGesttureRecognizer and provides them with state
+    final class VerticalGestureState {
+
+        private unowned let handler: VerticalHandler
+        private var initialPoint: CGPoint?
+        private var currentPoint: CGPoint?
+
+        // MARK: - Properties
+
+        /// Tells us if the gesture has passed the threshold of Constants.minTranslation at least once
+        private(set) var didPan: Bool = false
+        var startMode: PanelGestures.StartMode = .onFixedArea
+
+        init(handler: VerticalHandler) {
+            self.handler = handler
+        }
+
+        @objc
+        func handlePan(_ pan: PanOrScrollGestureRecognizer) {
+            let location = pan.location(in: pan.view?.window)
+            self.currentPoint = location
+
+            switch pan.state {
+            case .possible:
+                break
+            case .began:
+                self.initialPoint = location
+
+            case .changed:
+                self.currentPoint = location
+                if self.totalTranslation(in: pan.view).hypotenuse() >= Constants.minTranslation, self.didPan == false {
+                    self.didPan = true
+
+                    guard self.totalTranslation(in: pan.view).direction() == .vertical else {
+                        pan.state = .cancelled
+                        return
+                    }
+                }
+
+            case .ended, .failed, .cancelled:
+                self.handler.handlePan(pan, state: self)
+                self.cleanup() // We can't use defer for this because we're in a switch statement
+                return
+
+            @unknown default:
+                break
+            }
+
+            self.handler.handlePan(pan, state: self)
+        }
+
+        // MARK: - Private
+
+        private func cleanup() {
+            self.didPan = false
+            self.startMode = .onFixedArea
+        }
+
+        private func totalTranslation(in view: UIView?) -> CGPoint {
+            guard let view = view else { return .zero }
+            guard let initialPoint = self.initialPoint else { return .zero }
+            guard let currentPoint = self.currentPoint else { return .zero }
+
+            return self.translation(from: initialPoint, to: currentPoint, in: view)
+        }
+
+        private func translation(from startPoint: CGPoint, to endPoint: CGPoint, in view: UIView) -> CGPoint {
+            guard let window = view.window else { return .zero }
+
+            let startPointInView = window.convert(startPoint, to: view)
+            let endPointInView = window.convert(endPoint, to: view)
+
+            return CGPoint(x: endPointInView.x - startPointInView.x, y: endPointInView.y - startPointInView.y)
+        }
+    }
 
     // MARK: - VerticalHandler
 
@@ -326,26 +418,20 @@ private extension PanelGestures {
             self.gestures = gestures
         }
 
-        typealias GestureRecognizer = UIGestureRecognizer & PanGestureRecognizerProtocol
-
-        func shouldStartPan(_ pan: GestureRecognizer) -> Bool {
+        func shouldStartPan(_ pan: PanOrScrollGestureRecognizer) -> Bool {
             guard let contentViewController = self.panel.contentViewController else { return true }
 
             return self.gestures.gestureRecognizer(pan, isWithinContentAreaOf: contentViewController) == false || self.gestures.gestureRecognizer(pan, isAllowedToStartByContentOf: contentViewController)
         }
 
-        @objc
-        func handlePan(_ pan: UIGestureRecognizer) {
-            // cannot use GestureRecognizer in method signature because 'PanGestureRecognizerProtocol' cannot be represented in objc
-            guard let pan = pan as? GestureRecognizer else { return }
-
+        func handlePan(_ pan: PanOrScrollGestureRecognizer, state: VerticalGestureState) {
             switch pan.state {
             case .began:
-                self.handlePanStarted(pan)
+                self.handlePanStarted(pan, state: state)
             case .changed:
-                self.handlePanChanged(pan)
+                self.handlePanChanged(pan, state: state)
             case .ended:
-                self.handlePanEnded(pan)
+                self.handlePanEnded(pan, state: state)
             case .cancelled:
                 self.handlePanCancelled(pan)
             default:
@@ -353,21 +439,21 @@ private extension PanelGestures {
             }
         }
 
-        private func handlePanStarted(_ pan: GestureRecognizer) {
+        private func handlePanStarted(_ pan: PanOrScrollGestureRecognizer, state: VerticalGestureState) {
             let configuration = PanelGestures.Configuration(mode: self.panel.configuration.mode, animateChanges: self.panel.animator.animateChanges)
             // remember initial state
             self.originalConfiguration = configuration
 
             if let contentViewController = self.panel.contentViewController {
                 if self.gestures.gestureRecognizer(pan, isWithinContentAreaOf: contentViewController), let scrollView = self.gestures.verticallyScrollableView(of: contentViewController, interactingWith: pan) {
-                    pan.startMode = .onVerticallyScrollableArea(competingScrollView: scrollView)
+                    state.startMode = .onVerticallyScrollableArea(competingScrollView: scrollView)
                 } else {
-                    pan.startMode = .onFixedArea
+                    state.startMode = .onFixedArea
                 }
             }
         }
 
-        private func handlePanDragStart(_ pan: GestureRecognizer) -> Bool {
+        private func handlePanDragStart(_ pan: PanOrScrollGestureRecognizer, state: VerticalGestureState) -> Bool {
             self.panel.animator.animateChanges = false
             self.panel.animator.performWithoutAnimation {
                 self.panel.constraints.updateForPanStart(with: self.panel.view.frame.size)
@@ -378,7 +464,7 @@ private extension PanelGestures {
 
             let velocity = pan.velocity(in: self.panel.view)
 
-            if case .onVerticallyScrollableArea(let scrollView) = pan.startMode {
+            if case .onVerticallyScrollableArea(let scrollView) = state.startMode {
                 if velocity.y < 0.0 {
                     // if the gesture scrolls the content, cancel the resizing gesture itself
                     pan.cancel()
@@ -396,7 +482,7 @@ private extension PanelGestures {
             return true
         }
 
-        private func handlePanChanged(_ pan: GestureRecognizer) {
+        private func handlePanChanged(_ pan: PanOrScrollGestureRecognizer, state: VerticalGestureState) {
             func dragOffset(for translation: CGPoint) -> CGFloat {
                 let fudgeFactor: CGFloat = 60.0
                 let minHeight = self.height(for: .compact) + fudgeFactor
@@ -405,7 +491,7 @@ private extension PanelGestures {
 
                 // slow down resizing if the current height exceeds certain limits
                 let isNearingEdge = (currentHeight < minHeight && translation.y > 0.0) || (currentHeight > maxHeight && translation.y < 0.0)
-                let isShrinkingOnScrollView = pan.startMode != .onFixedArea && translation.y > 0.0
+                let isShrinkingOnScrollView = state.startMode != .onFixedArea && translation.y > 0.0
                 if isNearingEdge || isShrinkingOnScrollView {
                     return translation.y / 3.0
                 } else {
@@ -417,22 +503,25 @@ private extension PanelGestures {
             let yOffset = dragOffset(for: translation)
             guard yOffset != 0.0 else { return }
 
+            // We reset the translation to get incremental updates from now on
             pan.setTranslation(.zero, in: self.panel.view)
-            guard pan.didPan else { return }
+
+            // However, didPan still works with totalTranslation under the covers
+            guard state.didPan else { return }
 
             if pan.cancelsTouchesInView == false {
-                guard self.handlePanDragStart(pan) else { return }
+                guard self.handlePanDragStart(pan, state: state) else { return }
             }
 
             self.panel.animator.performWithoutAnimation { self.panel.constraints.updateForPan(with: yOffset) }
             self.panel.animator.notifyDelegateOfTransition(to: CGSize(width: self.panel.view.frame.width, height: self.panel.currentHeight))
         }
 
-        private func handlePanEnded(_ pan: GestureRecognizer) {
+        private func handlePanEnded(_ pan: PanOrScrollGestureRecognizer, state: VerticalGestureState) {
             guard let originalMode = self.originalConfiguration?.mode else { return }
 
             self.panel.constraints.updateForPanEnd()
-            guard pan.didPan || originalMode == .minimal else {
+            guard state.didPan || originalMode == .minimal else {
                 self.handlePanCancelled(pan)
                 return
             }
@@ -444,7 +533,7 @@ private extension PanelGestures {
             self.cleanUp(pan: pan)
         }
 
-        private func handlePanCancelled(_ pan: GestureRecognizer) {
+        private func handlePanCancelled(_ pan: PanOrScrollGestureRecognizer) {
             guard let originalMode = self.originalConfiguration?.mode else { return }
 
             let currentHeight = self.panel.currentHeight
@@ -458,7 +547,7 @@ private extension PanelGestures {
         }
 
         // swiftlint:disable:next cyclomatic_complexity
-        private func targetMode(for pan: GestureRecognizer) -> Panel.Configuration.Mode {
+        private func targetMode(for pan: PanOrScrollGestureRecognizer) -> Panel.Configuration.Mode {
             let supportedModes = self.panel.configuration.supportedModes
             guard let originalConfiguration = self.originalConfiguration else { return supportedModes.first! }
 
@@ -517,7 +606,7 @@ private extension PanelGestures {
             }
         }
 
-        private func cleanUp(pan: GestureRecognizer) {
+        private func cleanUp(pan: PanOrScrollGestureRecognizer) {
             pan.cancelsTouchesInView = false
 
             guard let originalConfiguration = self.originalConfiguration else { return }
@@ -535,7 +624,7 @@ private extension PanelGestures {
             }
         }
 
-        private func initialVelocity(for pan: GestureRecognizer, targetMode: Panel.Configuration.Mode) -> CGFloat {
+        private func initialVelocity(for pan: PanOrScrollGestureRecognizer, targetMode: Panel.Configuration.Mode) -> CGFloat {
             let velocity = pan.velocity(in: self.panel.view).y
             let currentHeight = self.panel.currentHeight
             let targetHeight = self.height(for: targetMode)
@@ -600,14 +689,14 @@ private extension PanelGestures {
     }
 
     func makeVerticalPointerScrollGestureRecognizer() -> PointerScrollGestureRecognizer {
-        let gesture = PointerScrollGestureRecognizer(target: self.verticalHandler, action: #selector(VerticalHandler.handlePan))
+        let gesture = PointerScrollGestureRecognizer(target: self.verticalPointerScrollState, action: #selector(VerticalGestureState.handlePan))
         gesture.delegate = self
         gesture.cancelsTouchesInView = false
         return gesture
     }
 
-    func makeVerticalPanGestureRecognizer() -> PanGestureRecognizer {
-        let pan = PanGestureRecognizer(target: self.verticalHandler, action: #selector(VerticalHandler.handlePan))
+    func makeVerticalPanGestureRecognizer() -> NoDelayPanGestureRecognizer {
+        let pan = NoDelayPanGestureRecognizer(target: self.verticalPanState, action: #selector(VerticalGestureState.handlePan))
         pan.delegate = self
         pan.cancelsTouchesInView = false
         return pan
@@ -705,5 +794,24 @@ private extension Panel {
 
     var currentHeight: CGFloat {
         return self.constraints.heightConstraint!.constant
+    }
+}
+
+private extension CGPoint {
+
+    enum Direction {
+        case horizontal
+        case vertical
+    }
+
+    func hypotenuse() -> CGFloat {
+        return sqrt(self.x * self.x + self.y * self.y)
+    }
+
+    func direction() -> Direction {
+        let horizontalDiff = self.x * self.x
+        let verticalDiff = self.y * self.y
+
+        return horizontalDiff > verticalDiff ? .horizontal : .vertical
     }
 }

--- a/Aiolos/Aiolos/Sources/PanelGestures.swift
+++ b/Aiolos/Aiolos/Sources/PanelGestures.swift
@@ -324,7 +324,7 @@ private extension PanelGestures {
 
     // MARK: - VerticalGestureState
 
-    /// Handles QuickPanGestureRecognizer and PointerScrollGesttureRecognizer and provides them with state
+    /// Handles NoDelayPanGestureRecognizer and PointerScrollGestureRecognizer and provides them with state
     final class VerticalGestureState {
 
         private unowned let handler: VerticalHandler

--- a/Aiolos/Aiolos/Sources/PanelGestures.swift
+++ b/Aiolos/Aiolos/Sources/PanelGestures.swift
@@ -16,7 +16,7 @@ final class PanelGestures: NSObject {
     private unowned let panel: Panel
 
     private lazy var horizontalPan: HorizontalPanGestureRecognizer = self.makeHorizontalPanGestureRecognizer()
-    private lazy var pointerScroll: PointerScrollGestureRecognizer = self.makePointerScrollGestureRecognizer()
+    private lazy var verticalPointerScroll: PointerScrollGestureRecognizer = self.makeVerticalPointerScrollGestureRecognizer()
     private lazy var verticalPan: PanGestureRecognizer = self.makeVerticalPanGestureRecognizer()
     private lazy var horizontalHandler: HorizontalHandler = HorizontalHandler(gestures: self)
     private lazy var verticalHandler: VerticalHandler = VerticalHandler(gestures: self)
@@ -26,9 +26,9 @@ final class PanelGestures: NSObject {
         set { self.horizontalPan.isEnabled = newValue }
     }
 
-    private var isPointerScrollEnabled: Bool {
-        get { return self.pointerScroll.isEnabled }
-        set { self.pointerScroll.isEnabled = newValue }
+    private var isVerticalPointerScrollEnabled: Bool {
+        get { return self.verticalPointerScroll.isEnabled }
+        set { self.verticalPointerScroll.isEnabled = newValue }
     }
 
     private var isVerticalPanEnabled: Bool {
@@ -46,20 +46,20 @@ final class PanelGestures: NSObject {
 
     func install() {
         self.panel.view.addGestureRecognizer(self.horizontalPan)
-        self.panel.view.addGestureRecognizer(self.pointerScroll)
+        self.panel.view.addGestureRecognizer(self.verticalPointerScroll)
         self.panel.view.addGestureRecognizer(self.verticalPan)
         self.configure(with: self.panel.configuration)
     }
 
     func configure(with configuration: Panel.Configuration) {
         self.isHorizontalPanEnabled = configuration.isHorizontalPositioningEnabled
-        self.isPointerScrollEnabled = configuration.gestureResizingMode != .disabled // TODO: add a dedicated config option for pointer scroll
+        self.isVerticalPointerScrollEnabled = configuration.gestureResizingMode != .disabled // TODO: add a dedicated config option for pointer scroll
         self.isVerticalPanEnabled = configuration.gestureResizingMode != .disabled
     }
 
     func cancel() {
         self.horizontalPan.cancel()
-        self.pointerScroll.cancel()
+        self.verticalPointerScroll.cancel()
         self.verticalPan.cancel()
     }
 }
@@ -76,8 +76,8 @@ extension PanelGestures: UIGestureRecognizerDelegate {
         switch gestureRecognizer {
         case self.horizontalPan:
             return self.horizontalHandler.shouldStartPan(self.horizontalPan)
-        case self.pointerScroll:
-            return self.verticalHandler.shouldStartPan(self.pointerScroll)
+        case self.verticalPointerScroll:
+            return self.verticalHandler.shouldStartPan(self.verticalPointerScroll)
         case self.verticalPan:
             return self.verticalHandler.shouldStartPan(self.verticalPan)
         default:
@@ -96,7 +96,7 @@ extension PanelGestures: UIGestureRecognizerDelegate {
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRequireFailureOf otherGestureRecognizer: UIGestureRecognizer) -> Bool {
         // horizontal and vertical pan (or pointer scroll) should not happen together
         if gestureRecognizer == self.horizontalPan {
-            return otherGestureRecognizer == self.verticalPan || otherGestureRecognizer == self.pointerScroll
+            return otherGestureRecognizer == self.verticalPan || otherGestureRecognizer == self.verticalPointerScroll
         }
 
         if let shouldRequireFailureOf = self.panel.gestureDelegate?.gestureRecognizer?(gestureRecognizer, shouldRequireFailureOf: otherGestureRecognizer) {
@@ -593,7 +593,7 @@ private extension PanelGestures {
         return pan
     }
 
-    func makePointerScrollGestureRecognizer() -> PointerScrollGestureRecognizer {
+    func makeVerticalPointerScrollGestureRecognizer() -> PointerScrollGestureRecognizer {
         let gesture = PointerScrollGestureRecognizer(target: self.verticalHandler, action: #selector(VerticalHandler.handlePan))
         gesture.delegate = self
         gesture.cancelsTouchesInView = false
@@ -612,7 +612,7 @@ private extension PanelGestures {
             let states: Set<UIGestureRecognizer.State> = [.began, .changed]
             let isPanningHorizontally = states.contains(self.horizontalPan.state)
             let isPanningVertically = states.contains(self.verticalPan.state)
-            let isPointerScrolling = states.contains(self.pointerScroll.state)
+            let isPointerScrolling = states.contains(self.verticalPointerScroll.state)
 
             return isPanningHorizontally || isPanningVertically || isPointerScrolling
         }

--- a/Aiolos/Aiolos/Sources/PanelGestures.swift
+++ b/Aiolos/Aiolos/Sources/PanelGestures.swift
@@ -337,9 +337,13 @@ private extension PanelGestures {
         private(set) var didPan: Bool = false
         var startMode: PanelGestures.StartMode = .onFixedArea
 
+        // MARK: - Lifecycle
+
         init(handler: VerticalHandler) {
             self.handler = handler
         }
+
+        // MARK: - VerticalGestureState
 
         @objc
         func handlePan(_ pan: PanOrScrollGestureRecognizer) {

--- a/Aiolos/Aiolos/Sources/ResizeHandle.swift
+++ b/Aiolos/Aiolos/Sources/ResizeHandle.swift
@@ -57,7 +57,7 @@ public final class ResizeHandle: UIView {
         self.addSubview(self.resizeHandle)
         self.configure(with: configuration)
 
-        if #available(iOS 13.4, *) {
+        if #available(iOS 13.4, *), NSClassFromString("UIPointerInteraction") != nil {
             let pointerInteraction = UIPointerInteraction(delegate: self)
             self.addInteraction(pointerInteraction)
         }

--- a/Aiolos/Aiolos/Sources/ResizeHandle.swift
+++ b/Aiolos/Aiolos/Sources/ResizeHandle.swift
@@ -81,7 +81,7 @@ public final class ResizeHandle: UIView {
 
         self.handleColor = foregroundColor
         self.backgroundColor = backgroundColor
-        self.resizeHandle.alpha = configuration.gestureResizingMode != .disabled && configuration.supportedModes.count > 1 ? 1.0 : 0.2
+        self.resizeHandle.alpha = configuration.gestureResizingMode.contains(.handle) && configuration.supportedModes.count > 1 ? 1.0 : 0.2
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/IdeasOnCanvas/MindNode/issues/5976

# Goal of this PR

Allow scrolling with pointer to resize/move panel as it is possible by swiping with finger.

As we use a custom UIGestureRecognizer subclass to resize the panel, we cannot simply enable pointer scroll recognition. This can be done in `HorizontalPanGestureRecognizer` which is a `UIPanGestureRecognizer` subclass but for regognizing vertical scrolls, we need to use another geture recognizer - `PointerScrollGestureRecognizer`.

# Info for the Reviewer

This PR purely additive functionality-wise. It also contains some refactoring. For example, `GestureResizingMode` is now a `OptionSets` and not available from ObjC anymore. If ObjC compatibility is important, we can fix this as described in comment: https://github.com/IdeasOnCanvas/Aiolos/pull/35/files#r486418120

# GIF

![RPReplay_Final1599751870](https://user-images.githubusercontent.com/198316/92754935-a60b8d00-f38b-11ea-82da-4361b77251ea.gif)

