### PR TITLE
Fix complaint of Xcode 13.3 by moving headers phase before compile phase

### DIFF
--- a/Aiolos/Aiolos.xcodeproj/project.pbxproj
+++ b/Aiolos/Aiolos.xcodeproj/project.pbxproj
@@ -215,9 +215,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 9B22526E1F1508FD006DE55D /* Build configuration list for PBXNativeTarget "Aiolos" */;
 			buildPhases = (
+				9B2252541F1508FD006DE55D /* Headers */,
 				9B2252521F1508FD006DE55D /* Sources */,
 				9B2252531F1508FD006DE55D /* Frameworks */,
-				9B2252541F1508FD006DE55D /* Headers */,
 				9B2252551F1508FD006DE55D /* Resources */,
 			);
 			buildRules = (


### PR DESCRIPTION
Fixes a build error in Xcode 13.3 beta 1:

<img width="1187" alt="Bildschirmfoto 2022-01-31 um 17 22 41" src="https://user-images.githubusercontent.com/1856655/151831969-8354591a-284f-4598-a437-43e4d014558c.png">


```
Cycle inside Aiolos; building could produce unreliable results. This usually can be resolved by moving the target's Headers build phase before Compile Sources.
```